### PR TITLE
Added composer Docker container and setup details.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,43 @@
 # FlexibleMink
 Mink extension with patient assertions and object storage
+
+Installing Development Pre-Requisites
+-------------------------------------
+
+Install [Docker Toolbox](https://www.docker.com/toolbox).
+
+Once installed, initialize and start the VM by running the "Docker Quickstart Terminal" application located in `/Applications/Docker`.
+
+Add the following to your shell profile:
+
+```
+eval $(docker-machine env default)
+```
+
+Some profile locations for different shells:
+
+* general: `~/.profile`
+* bash: `~/.bashrc`
+* zsh: `~/.zshrc`
+
+Reload your profile to apply the changes, e.g.:
+
+```bash
+. ~/.profile
+```
+
+You will also want to ensure that `./bin` is in your `$PATH` and is the highest priority. You can do so by adding the
+following to the end of the same profile mentioned above:
+
+```
+export PATH=./bin:$PATH
+```
+
+Installing The Project for Development
+--------------------------------------
+
+Initialize the project:
+
+```bash
+composer install
+```

--- a/bin/composer
+++ b/bin/composer
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+ACCOUNT=chekote
+REPO=composer
+VERSION=php5.4.45-2016-03-27-16-14-51
+
+. "${DIR}"/lib/args.sh
+
+COMMAND="echo pid1 > /dev/null && composer $ARGS"
+
+docker run -it -v ~/.composer:/root/.composer -v $(pwd):/data --rm ${ACCOUNT}/${REPO}:${VERSION} "${COMMAND}"

--- a/bin/lib/args.sh
+++ b/bin/lib/args.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+# (re)add double quotes around arguments
+ARGS=''
+for i in "$@"; do
+    ARGS="$ARGS \"${i//\"/\\\"}\""
+done


### PR DESCRIPTION
The default Mac installation of PHP does not include mbstring, which is required to install the composer dependencies for this project.

I added the composer Docker container so that anyone who wishes to work on the project is not required to understand how to install PHP modules.