### PR TITLE
Added Step Definition for Storing a new Reference

### DIFF
--- a/src/Behat/FlexibleMink/Context/StoreContext.php
+++ b/src/Behat/FlexibleMink/Context/StoreContext.php
@@ -108,4 +108,14 @@ trait StoreContext
     {
         return $nth ? isset($this->registry[$key][$nth - 1]) : isset($this->registry[$key]);
     }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @When /^(?:I |)refer to (?:the |)"(?P<current>[^"]*)" as "(?P<new>[^"]*)"$/
+     */
+    public function referToStoredAs($current, $new)
+    {
+        $this->put($this->get($current), $new);
+    }
 }

--- a/src/Behat/FlexibleMink/PseudoInterface/StoreContextInterface.php
+++ b/src/Behat/FlexibleMink/PseudoInterface/StoreContextInterface.php
@@ -64,4 +64,12 @@ trait StoreContextInterface
      * @param string $key   The key to store the thing under.
      */
     abstract protected function put($thing, $key);
+
+    /**
+     * Adds a reference to a stored thing under the new specified key.
+     *
+     * @param string $current The current key of the thing.
+     * @param string $new     The new key under which to store the thing.
+     */
+    abstract public function referToStoredAs($current, $new);
 }


### PR DESCRIPTION
This new step definition allows a stored thing to be referred to by a name called out in the scenario. For instance, if there is a step that stores a user under the generic name "user" (`Given there is a user`), that user could then be referred to by name (`And I refer to the "user" as "John"`). This might be done when wanting to create multiple instances of a user each with different names.