### PR TITLE
Fix 'Ambiguous match' error for assertThingIs.

### DIFF
--- a/src/Behat/FlexibleMink/Context/StoreContext.php
+++ b/src/Behat/FlexibleMink/Context/StoreContext.php
@@ -29,7 +29,7 @@ trait StoreContext
     /**
      * {@inheritdoc}
      *
-     * @Then /^the "(?P<key>[^"]+)" should be (?P<value>.*)$/
+     * @Then /^the "(?P<key>[^"]+)" should be (?P<value>true|false|(?:\d*[.])?\d+|'(?:[^']|\\')*'|"(?:[^"]|\\"|)*")$/
      */
     public function assertThingIs($key, $expected = null)
     {


### PR DESCRIPTION
The assertThingIsMethod is matching any pattern that starts with 'the "key" should be ', which is quite broad
and has caused problems with other projects which are using more specific steps such as:

'the "key" should be CSV data...'

I have modified the pattern for assertThingIs to only accept data types that match the ones supported by TypeCaster:

* bools: true, false
* ints: 1, 2, 100, etc
* floats: 1.1, .1 etc
* quoted strings: 'the bird', "is the word", etc.