### PR TITLE
add assertions for input field(s) existence

### DIFF
--- a/src/Behat/FlexibleMink/Context/FlexibleContext.php
+++ b/src/Behat/FlexibleMink/Context/FlexibleContext.php
@@ -3,6 +3,7 @@
 namespace Behat\FlexibleMink\Context;
 
 use Behat\FlexibleMink\PseudoInterface\FlexibleContextInterface;
+use Behat\Gherkin\Node\TableNode;
 use Behat\Mink\Element\NodeElement;
 use Behat\Mink\Exception\ExpectationException;
 use Behat\Mink\Exception\UnsupportedDriverActionException;
@@ -74,5 +75,85 @@ class FlexibleContext extends MinkContext
         }
 
         throw new ExpectationException("No visible link found for '$locator'", $this->getSession());
+    }
+
+
+    /**
+     * {@inheritdoc}
+     */
+    public function assertFieldExists($fieldName)
+    {
+        /** @var NodeElement[] $fields */
+        $fields = $this->getSession()->getPage()->findAll('named', ['field', $fieldName]);
+        if (count($fields) == 0) {
+            // If the field was not found with the usual way above, attempt to find with label name as last resort
+            $label = $this->getSession()->getPage()->find('xpath', "//label[contains(text(), '$fieldName')]");
+            if (!$label) {
+                throw new ExpectationException("No input label '$fieldName' found", $this->getSession());
+            }
+            $name = $label->getAttribute('for');
+            $fields = [$this->getSession()->getPage()->findField($name)];
+        }
+        if (count($fields) > 0) {
+            foreach ($fields as $field) {
+                if ($field->isVisible()) {
+                    return $field;
+                }
+            }
+        }
+        throw new ExpectationException("No visible input found for '$fieldName'", $this->getSession());
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function assertFieldNotExists($fieldName)
+    {
+        /** @var NodeElement[] $fields */
+        $fields = $this->getSession()->getPage()->findAll('named', ['field', $fieldName]);
+        if (count($fields) == 0) {
+            // If the field was not found with the usual way above, attempt to find with label name as last resort
+            /* @var NodeElement[] $label */
+            $labels = $this->getSession()->getPage()->findAll('xpath', "//label[contains(text(), '$fieldName')]");
+            if (count($labels) > 0) {
+                foreach ($labels as $item) {
+                    /** @var NodeElement $item */
+                    if ($item->isVisible()) {
+                        throw new ExpectationException("Input label '$fieldName' found", $this->getSession());
+                    }
+                }
+            }
+        } else {
+            foreach ($fields as $field) {
+                /** @var NodeElement $field */
+                if ($field->isVisible()) {
+                    throw new ExpectationException("Input label '$fieldName' found", $this->getSession());
+                }
+            }
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @Then /^I should see the following fields:$/
+     */
+    public function assertPageContainsFields(TableNode $tableNode)
+    {
+        foreach ($tableNode->getRowsHash() as $field => $value) {
+            $this->assertFieldExists($field);
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @Then /^I should not see the following fields:$/
+     */
+    public function assertPageNotContainsFields(TableNode $tableNode)
+    {
+        foreach ($tableNode->getRowsHash() as $field => $value) {
+            $this->assertFieldNotExists($field);
+        }
     }
 }

--- a/src/Behat/FlexibleMink/Context/FlexibleContext.php
+++ b/src/Behat/FlexibleMink/Context/FlexibleContext.php
@@ -77,7 +77,6 @@ class FlexibleContext extends MinkContext
         throw new ExpectationException("No visible link found for '$locator'", $this->getSession());
     }
 
-
     /**
      * {@inheritdoc}
      */

--- a/src/Behat/FlexibleMink/PseudoInterface/FlexibleContextInterface.php
+++ b/src/Behat/FlexibleMink/PseudoInterface/FlexibleContextInterface.php
@@ -2,6 +2,9 @@
 
 namespace Behat\FlexibleMink\PseudoInterface;
 
+use Behat\Gherkin\Node\TableNode;
+use Behat\Mink\Element\NodeElement;
+use Behat\Mink\Exception\ExpectationException;
 use Behat\Mink\Session;
 
 /**
@@ -44,4 +47,37 @@ trait FlexibleContextInterface
      * @param string $locator The id|title|alt|text of the link to be clicked.
      */
     abstract public function clickLink($locator);
+
+    /**
+     * Checks that the page contains a visible input field and then returns it.
+     *
+     * @param $fieldName
+     * @throws ExpectationException If a visible input field is not found.
+     * @return NodeElement          The found input field.
+     */
+    abstract public function assertFieldExists($fieldName);
+
+    /**
+     * Checks that the page not contain a visible input field.
+     *
+     * @param  string               $fieldName The name of the input field.
+     * @throws ExpectationException If a visible input field is found.
+     */
+    abstract public function assertFieldNotExists($fieldName);
+
+    /**
+     * This method will check if all the fields exists and visible in the current page.
+     *
+     * @param  TableNode            $tableNode The id|name|title|alt|value of the input field
+     * @throws ExpectationException if any of the fields is not visible in the page
+     */
+    abstract public function assertPageContainsFields(TableNode $tableNode);
+
+    /**
+     * This method will check if all the fields not exists or not visible in the current page.
+     *
+     * @param  TableNode            $tableNode The id|name|title|alt|value of the input field
+     * @throws ExpectationException if any of the fields is visible in the page
+     */
+    abstract public function assertPageNotContainsFields(TableNode $tableNode);
 }


### PR DESCRIPTION
add assertions to check if individual|groups of input field is [not] existing in the current page.