### PR TITLE
CSV/download checking utilities

### DIFF
--- a/src/Behat/FlexibleMink/Context/CsvContext.php
+++ b/src/Behat/FlexibleMink/Context/CsvContext.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Behat\FlexibleMink\Context;
+
+use Behat\FlexibleMink\PseudoInterface\CsvContextInterface;
+use Behat\FlexibleMink\PseudoInterface\FlexibleContextInterface;
+use Behat\FlexibleMink\PseudoInterface\StoreContextInterface;
+use Behat\Gherkin\Node\TableNode;
+use Behat\Mink\Exception\ExpectationException;
+use Exception;
+
+/**
+ * {@inheritdoc}
+ */
+trait CsvContext
+{
+    // Implements
+    use CsvContextInterface;
+
+    // Depends
+    use FlexibleContextInterface;
+    use StoreContextInterface;
+
+    /**
+     * {@inheritdoc}
+     *
+     * @Then /^the "(?P<key>[^"]+)" should be CSV data as follows:$/
+     */
+    public function assertThingIsCSVWithData($key, TableNode $table)
+    {
+        $expectedData = $table->getRows();
+
+        // Use str_getcsv to first split the CSV data into rows, then again to process each row.
+        $actualData = array_map('str_getcsv', str_getcsv($this->get($key), "\n"));
+
+        if (($expectedCount = count($expectedData)) !== ($actualCount = count($actualData))) {
+            throw new Exception("Expected $expectedCount rows, but found $actualCount");
+        }
+
+        // record the column numbers for the expected and actual headers so we can
+        // compare similarly named columns even if they are not in the same order.
+        $expectedHeaders = array_flip($expectedData[0]);
+        $actualHeaders = array_flip($actualData[0]);
+        unset($expectedData[0]);
+        unset($actualData[0]);
+
+        // iterate over each expected row
+        foreach ($expectedData as $rowNum => $expectedRow) {
+            $actualRow = $actualData[$rowNum];
+
+            // iterate over each expected column
+            foreach ($expectedHeaders as $name => $colNum) {
+                $expectedValue = isset($expectedRow[$colNum]) ? $expectedRow[$colNum] : null;
+                $actualValue = isset($actualRow[$actualHeaders[$name]]) ? $actualRow[$actualHeaders[$name]] : null;
+
+                // check values match
+                if ($expectedValue != $actualValue) {
+                    throw new ExpectationException(
+                        "Expected '$expectedValue' for '$name' in row $rowNum, but found '$actualValue'",
+                        $this->getSession()
+                    );
+                }
+            }
+        }
+    }
+}

--- a/src/Behat/FlexibleMink/Context/FlexibleContext.php
+++ b/src/Behat/FlexibleMink/Context/FlexibleContext.php
@@ -50,6 +50,14 @@ class FlexibleContext extends MinkContext
      */
     public function clickLink($locator)
     {
+        $this->assertVisibleLink($locator)->click();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function assertVisibleLink($locator)
+    {
         $locator = $this->fixStepArgument($locator);
 
         $links = $this->getSession()->getPage()->findAll(
@@ -62,15 +70,11 @@ class FlexibleContext extends MinkContext
             try {
                 $visible = $link->isVisible();
             } catch (UnsupportedDriverActionException $e) {
-                $link->click();
-
-                return;
+                return $link;
             }
 
             if ($visible) {
-                $link->click();
-
-                return;
+                return $link;
             }
         }
 

--- a/src/Behat/FlexibleMink/Context/WebDownloadContext.php
+++ b/src/Behat/FlexibleMink/Context/WebDownloadContext.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Behat\FlexibleMink\Context;
+
+use Behat\FlexibleMink\PseudoInterface\FlexibleContextInterface;
+use Behat\FlexibleMink\PseudoInterface\StoreContextInterface;
+use Behat\FlexibleMink\PseudoInterface\WebDownloadContextInterface;
+
+/**
+ * {@inheritdoc}
+ */
+trait WebDownloadContext
+{
+    // Implements
+    use WebDownloadContextInterface;
+
+    // Depends
+    use FlexibleContextInterface;
+    use StoreContextInterface;
+
+    /**
+     * {@inheritdoc}
+     *
+     * @When I download a file via the :locator link
+     * @When I download a file to :key via the :locator link
+     */
+    public function downloadViaLink($locator, $key = 'Download')
+    {
+        $this->download($this->assertVisibleLink($locator)->getAttribute('href'), $key);
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @When I download the file :file
+     * @When I download the file :file to :key
+     */
+    public function download($file, $key = 'Download')
+    {
+        $data = $this->getSession()->evaluateScript(
+<<<JS
+            (function() {
+                var out;
+                $.ajax({
+                    'async' : false,
+                    'url' : '$file',
+                    'success' : function(data, status, xhr) {
+                        out = data;
+                    }
+                });
+
+                return out;
+            })();
+JS
+        );
+
+        $this->put($data, $key);
+    }
+}

--- a/src/Behat/FlexibleMink/PseudoInterface/CsvContextInterface.php
+++ b/src/Behat/FlexibleMink/PseudoInterface/CsvContextInterface.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Behat\FlexibleMink\PseudoInterface;
+
+use Behat\Gherkin\Node\TableNode;
+use Behat\Mink\Exception\ExpectationException;
+
+/**
+ * Provides functionality for working with CSV data.
+ */
+trait CsvContextInterface
+{
+    /**
+     * Ensures that the given variable in the store is a CSV containing the given rows.
+     * The given rows do not have to contain all columns in the store, but the CSV in the store
+     * must contain all of the columns in the expected rows.
+     *
+     * @Then /^the "(?P<key>[^"]+)" should be CSV data as follows:$/
+     * @param  string               $key   The key the CSV is stored under.
+     * @param  TableNode            $table The rows expected in the CSV.
+     * @throws ExpectationException if the given rows are not present in the CSV.
+     */
+    abstract public function assertThingIsCSVWithData($key, TableNode $table);
+}

--- a/src/Behat/FlexibleMink/PseudoInterface/FlexibleContextInterface.php
+++ b/src/Behat/FlexibleMink/PseudoInterface/FlexibleContextInterface.php
@@ -49,6 +49,17 @@ trait FlexibleContextInterface
     abstract public function clickLink($locator);
 
     /**
+     * Finds the first matching visible link on the page.
+     *
+     * Warning: Will return the first link if the driver does not support visibility checks.
+     *
+     * @param  string               $locator The link name.
+     * @throws ExpectationException If a visible link was not found.
+     * @return NodeElement          The link.
+     */
+    abstract public function assertVisibleLink($locator);
+
+    /**
      * Checks that the page contains a visible input field and then returns it.
      *
      * @param $fieldName

--- a/src/Behat/FlexibleMink/PseudoInterface/WebDownloadContextInterface.php
+++ b/src/Behat/FlexibleMink/PseudoInterface/WebDownloadContextInterface.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Behat\FlexibleMink\PseudoInterface;
+
+/**
+ * Provides functionality for working with downloaded files via a web browser.
+ */
+trait WebDownloadContextInterface
+{
+    /**
+     * Downloads the file references by the link and stores the content under the given key in the store.
+     *
+     * @param string $locator The id|label of the link.
+     * @param string $key     The key to store the content under, defaulting to "Download".
+     */
+    abstract public function downloadViaLink($locator, $key = 'Download');
+
+    /**
+     * Downloads the specified file and stores the content under the given key in the store.
+     *
+     * @param string $file the URL for the file to download.
+     * @param string $key  The key to store the content under, defaulting to "Download".
+     */
+    abstract public function download($file, $key = 'Download');
+}


### PR DESCRIPTION
I stole these contexts from Donald's pull request elsewhere to put them there lol

Some new contexts for checking the contexts of a CSV download. I opted not to `use` them by default and let the user import them if they want the functionality, since they aren't 100% related to the base FlexibleContext's goalset, but if we'd rather import them by default it'd be two extra lines to add that.