### PR TITLE
Add header checking to CsvContext

### DIFF
--- a/src/Behat/FlexibleMink/Context/CsvContext.php
+++ b/src/Behat/FlexibleMink/Context/CsvContext.php
@@ -70,4 +70,26 @@ trait CsvContext
             }
         }
     }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @Then /^the "(?P<key>[^"]+)" should be CSV data with the following headers:$/
+     */
+    public function assertThingIsCSVWithRows($key, TableNode $table)
+    {
+        $expectedHeaders = $table->getColumn(0);
+
+        $actualHeaders = str_getcsv(str_getcsv($this->get($key), "\n")[0]);
+
+        if ($diff = array_diff($expectedHeaders, $actualHeaders)) {
+            $missing = implode("', '", $diff);
+            throw new ExpectationException("CSV '$key' is missing rows '$missing'", $this->getSession());
+        }
+
+        if ($diff = array_diff($actualHeaders, $expectedHeaders)) {
+            $extra = implode("', '", $diff);
+            throw new ExpectationException("CSV '$key' contains extra rows '$extra'", $this->getSession());
+        }
+    }
 }

--- a/src/Behat/FlexibleMink/Context/CsvContext.php
+++ b/src/Behat/FlexibleMink/Context/CsvContext.php
@@ -50,6 +50,13 @@ trait CsvContext
 
             // iterate over each expected column
             foreach ($expectedHeaders as $name => $colNum) {
+                if (!isset($actualHeaders[$name])) {
+                    throw new ExpectationException(
+                        "Column $name does not exist, but was expected to",
+                        $this->getSession()
+                    );
+                }
+
                 $expectedValue = isset($expectedRow[$colNum]) ? $expectedRow[$colNum] : null;
                 $actualValue = isset($actualRow[$actualHeaders[$name]]) ? $actualRow[$actualHeaders[$name]] : null;
 

--- a/src/Behat/FlexibleMink/PseudoInterface/CsvContextInterface.php
+++ b/src/Behat/FlexibleMink/PseudoInterface/CsvContextInterface.php
@@ -21,4 +21,14 @@ trait CsvContextInterface
      * @throws ExpectationException if the given rows are not present in the CSV.
      */
     abstract public function assertThingIsCSVWithData($key, TableNode $table);
+
+    /**
+     * Ensures that the given variable in the store is a CSV with the given column headers.
+     * The CSV must contain exactly the rows given, and no more.
+     *
+     * @param  string               $key   The key the CSV is stored under.
+     * @param  TableNode            $table A list of headers that the CSV must match.
+     * @throws ExpectationException if the given headers are not an exact match with the CSV headers.
+     */
+    abstract public function assertThingIsCSVWithRows($key, TableNode $table);
 }


### PR DESCRIPTION
Allows for testing whether a given CSV contains exactly the given fields, no more, no less.