### PR TITLE
(#27) Added support for testing JS-sourced JSON objects key-by-key.

### DIFF
--- a/src/Behat/FlexibleMink/Context/JavaScriptContext.php
+++ b/src/Behat/FlexibleMink/Context/JavaScriptContext.php
@@ -59,7 +59,7 @@ trait JavaScriptContext
     /**
      * {@inheritdoc}
      *
-     * @Given /^the javascript variable :variableName should have the following contents:$/
+     * @Given the javascript variable :variableName should have the following contents:
      */
     public function assertJsonContentsOneByOne($variableName, TableNode $values)
     {

--- a/src/Behat/FlexibleMink/Context/JavaScriptContext.php
+++ b/src/Behat/FlexibleMink/Context/JavaScriptContext.php
@@ -57,19 +57,22 @@ trait JavaScriptContext
     }
 
     /**
-     * Selectively compares two JSON objects.
+     * {@inheritdoc}
      *
-     * @Given /^the javascript variable "([^"]*)" should have the following contents:$/
+     * @Given /^the javascript variable :variableName should have the following contents:$/
      */
-    public function assertJsonContentsOneByOne($variableName, TableNode $values, $count = null)
+    public function assertJsonContentsOneByOne($variableName, TableNode $values)
     {
-        $returnedJsonData = $this->getSession()->evaluateScript('return JSON.stringify(' . $variableName . ');');
+        $returnedJsonData = $this->getSession()->evaluateScript(
+            'return JSON.stringify(' . $variableName . ');'
+        );
         $response = json_decode($returnedJsonData, true);
 
         foreach ($values->getHash() as $row) {
             if (!isset($response[$row['key']])) {
                 throw new ExpectationException(
-                    sprintf('Expected key "%s" was not in the JS variable "%s"\nActual: %s', $row['key'], $variableName, $returnedJsonData),
+                    "Expected key \"{$row['key']}\" was not in the JS variable \"{$variableName}\"\n" .
+                        "Actual: $returnedJsonData",
                     $this->getSession()
                 );
             }
@@ -78,13 +81,20 @@ trait JavaScriptContext
 
             if ($actual != $expected) {
                 throw new ExpectationException(
-                    sprintf('Expected "%s" in %s position but got "%s"', $expected, $row['key'], $actual),
+                    "Expected \"$expected\" in {$row['key']} position but got \"$actual\"",
                     $this->getSession()
                 );
             }
         }
     }
 
+    /**
+     * Returns as-is literal inputs (string, int, float), otherwise
+     * returns the JSON encoded output.
+     *
+     * @param  mixed  $value
+     * @return string JSON encoded string
+     */
     protected function getRawOrJson($value)
     {
         if (is_array($value) || is_object($value)) {

--- a/src/Behat/FlexibleMink/PseudoInterface/JavaScriptContextInterface.php
+++ b/src/Behat/FlexibleMink/PseudoInterface/JavaScriptContextInterface.php
@@ -2,6 +2,7 @@
 
 namespace Behat\FlexibleMink\PseudoInterface;
 
+use Behat\Gherkin\Node\TableNode;
 use Behat\Mink\Exception\ExpectationException;
 
 /**
@@ -26,4 +27,13 @@ trait JavaScriptContextInterface
      * @throws ExpectationException if the type of the given variable does not match what's expected.
      */
     abstract public function assertJavascriptVariableType($variable, $not, $type);
+
+    /**
+     * Selectively compares two JSON objects.
+     *
+     * @param  string               $variableName The name of the JS variable to look for.
+     * @param  TableNode            $values       JavaScript variable key-value pair.
+     * @throws ExpectationException if the Javascript variable isn't a match
+     */
+    abstract public function assertJsonContentsOneByOne($variableName, TableNode $values);
 }


### PR DESCRIPTION
**Problem:** Testing for exact JSON objects is fraught with many grave difficulties, such as orderIds, dates and other dynamic data constantly changing.

**Solution:** This adds the ability to compare two JSON objects, one from JavaScript, one from the Behat tests, on a key-by-key basis, including the keys one wants to test, and ignoring the rest.