### PR TITLE
attach local file to remote browser session's 'file' input

### DIFF
--- a/src/Behat/FlexibleMink/Context/FlexibleContext.php
+++ b/src/Behat/FlexibleMink/Context/FlexibleContext.php
@@ -8,6 +8,7 @@ use Behat\Mink\Element\NodeElement;
 use Behat\Mink\Exception\ExpectationException;
 use Behat\Mink\Exception\UnsupportedDriverActionException;
 use Behat\MinkExtension\Context\MinkContext;
+use ZipArchive;
 
 /**
  * Overwrites some MinkContext step definitions to make them more resilient to failures caused by browser/driver
@@ -200,5 +201,36 @@ class FlexibleContext extends MinkContext
     {
         // set cookie:
         $this->getSession()->setCookie($key, null);
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @When /^(?:|I )attach the local file "(?P<path>[^"]*)" to "(?P<field>(?:[^"]|\\")*)"$/
+     */
+    public function addLocalFileToField($field, $path)
+    {
+        $field = $this->fixStepArgument($field);
+
+        if ($this->getMinkParameter('files_path')) {
+            $fullPath = rtrim(realpath($this->getMinkParameter('files_path')), DIRECTORY_SEPARATOR).DIRECTORY_SEPARATOR.$path;
+            if (is_file($fullPath)) {
+                $path = $fullPath;
+            }
+        }
+
+        $tempZip = tempnam('', 'WebDriverZip');
+        $zip = new ZipArchive();
+        $zip->open($tempZip, ZipArchive::CREATE);
+        $zip->addFile($path, basename($path));
+        $zip->close();
+
+        $remotePath = $this->getSession()->getDriver()->getWebDriverSession()->file([
+            'file' => base64_encode(file_get_contents($tempZip)),
+        ]);
+
+        $this->attachFileToField($field, $remotePath);
+
+        unlink($tempZip);
     }
 }

--- a/src/Behat/FlexibleMink/Context/FlexibleContext.php
+++ b/src/Behat/FlexibleMink/Context/FlexibleContext.php
@@ -208,12 +208,13 @@ class FlexibleContext extends MinkContext
      *
      * @When /^(?:|I )attach the local file "(?P<path>[^"]*)" to "(?P<field>(?:[^"]|\\")*)"$/
      */
-    public function addLocalFileToField($field, $path)
+    public function addLocalFileToField($path, $field)
     {
         $field = $this->fixStepArgument($field);
 
         if ($this->getMinkParameter('files_path')) {
-            $fullPath = rtrim(realpath($this->getMinkParameter('files_path')), DIRECTORY_SEPARATOR).DIRECTORY_SEPARATOR.$path;
+            $fullPath = rtrim(realpath($this->getMinkParameter('files_path')),
+                    DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR . $path;
             if (is_file($fullPath)) {
                 $path = $fullPath;
             }

--- a/src/Behat/FlexibleMink/PseudoInterface/FlexibleContextInterface.php
+++ b/src/Behat/FlexibleMink/PseudoInterface/FlexibleContextInterface.php
@@ -103,4 +103,13 @@ trait FlexibleContextInterface
      * @throws ExpectationException     If the option is exist/not exist as expected
      */
     abstract public function assertSelectContainsOption($select, $existence, $option);
+
+    /**
+     * Attaches a local file to field with specified id|name|label|value. This is used when running behat and
+     * browser session in different containers.
+     *
+     * @param string $field The file field to select the file with
+     * @param string $path  The local path of the file
+     */
+    abstract public function addLocalFileToField($field, $path);
 }


### PR DESCRIPTION
***Background***
When the behat and browser are running in different/isolated sessions, such as the configuration of RWB, we are unable to use `When I attach the file "logo.png" to "file"` because the `logo.png` is not existing in the browser session.

***Solution***
The code change here will first upload the file to the browser session, then attach the remote file to remote browser session to ensure the file is accessible.

[source](https://github.com/facebook/php-webdriver/blob/7cfa09f0a50b5e93087a9dc0eb669bc559eb9961/lib/Remote/RemoteWebElement.php#L329)