### PR TITLE
Fix scrollBodyTo won't work with floating elements

### DIFF
--- a/src/Behat/FlexibleMink/Context/FlexibleContext.php
+++ b/src/Behat/FlexibleMink/Context/FlexibleContext.php
@@ -241,10 +241,10 @@ class FlexibleContext extends MinkContext
      * @When /^(?:I |)scroll to the (?P<where>top|bottom) of the page$/
      * @Given /^the page is scrolled to the (?P<where>top|bottom)$/
      */
-    public function scrollBodyTo($where)
+    public function scrollWindowToBody($where)
     {
-        $alignToTop = ($where == 'top') ? 'true' : 'false';
+        $x = ($where == 'top') ? '0' : 'document.body.scrollHeight';
 
-        $this->getSession()->executeScript("document.body.scrollIntoView($alignToTop)");
+        $this->getSession()->executeScript("window.scrollTo(0, $x)");
     }
 }

--- a/src/Behat/FlexibleMink/PseudoInterface/FlexibleContextInterface.php
+++ b/src/Behat/FlexibleMink/PseudoInterface/FlexibleContextInterface.php
@@ -116,11 +116,11 @@ trait FlexibleContextInterface
     abstract public function addLocalFileToField($field, $path);
 
     /**
-     * Scrolls the viewport to the top or bottom of the page body.
+     * Scrolls the window to the top or bottom of the page body.
      *
      * @param  string                           $where to scroll to. Must be either "top" or "bottom".
      * @throws UnsupportedDriverActionException When operation not supported by the driver
      * @throws DriverException                  When the operation cannot be done
      */
-    abstract public function scrollBodyTo($where);
+    abstract public function scrollWindowToBody($where);
 }


### PR DESCRIPTION
__Method__
Create a HTML document with a floating element that extends beyond the bottom of the page.
Call scrollBodyTo('bottom').

__Expected Behavior__
The window should scroll to the bottom of the page.

__Actual Behavior__
The window does not scroll at all.

__Cause__
The floating element breaks the javascript scrollIntoView function.

__Resolution__
I changed the method to use window.scrollTo instead, which works fine with floating elements.