### PR TITLE
Add step to assert that lines are present in a given order

### DIFF
--- a/src/Behat/FlexibleMink/Context/FlexibleContext.php
+++ b/src/Behat/FlexibleMink/Context/FlexibleContext.php
@@ -8,6 +8,7 @@ use Behat\Mink\Element\NodeElement;
 use Behat\Mink\Exception\ExpectationException;
 use Behat\Mink\Exception\UnsupportedDriverActionException;
 use Behat\MinkExtension\Context\MinkContext;
+use InvalidArgumentException;
 use ZipArchive;
 
 /**
@@ -155,6 +156,10 @@ class FlexibleContext extends MinkContext
      */
     public function assertLinesInOrder(TableNode $table)
     {
+        if (count($table->getRow(0)) > 1) {
+            throw new InvalidArgumentException('Arguments must be a single-column list of items');
+        }
+
         $session = $this->getSession();
         $page = $session->getPage()->getText();
 

--- a/src/Behat/FlexibleMink/Context/FlexibleContext.php
+++ b/src/Behat/FlexibleMink/Context/FlexibleContext.php
@@ -151,6 +151,34 @@ class FlexibleContext extends MinkContext
     /**
      * {@inheritdoc}
      *
+     * @Then I should see the following lines in order:
+     */
+    public function assertLinesInOrder(TableNode $table)
+    {
+        $session = $this->getSession();
+        $page = $session->getPage()->getText();
+
+        $lines = $table->getColumn(0);
+        $lastPosition = -1;
+
+        foreach ($lines as $line) {
+            $position = strpos($page, $line);
+
+            if ($position === false) {
+                throw new ExpectationException("Line '$line' was not found on the page", $session);
+            }
+
+            if ($position < $lastPosition) {
+                throw new ExpectationException("Line '$line' came before its expected predecessor", $session);
+            }
+
+            $lastPosition = $position;
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     *
      * @Then /^I should see the following fields:$/
      */
     public function assertPageContainsFields(TableNode $tableNode)

--- a/src/Behat/FlexibleMink/PseudoInterface/FlexibleContextInterface.php
+++ b/src/Behat/FlexibleMink/PseudoInterface/FlexibleContextInterface.php
@@ -90,6 +90,14 @@ trait FlexibleContextInterface
     abstract public function assertFieldNotExists($fieldName);
 
     /**
+     * Checks that the page contains the given lines of text in the order specified.
+     *
+     * @param  TableNode            $table A list of text lines to look for.
+     * @throws ExpectationException if a line is not found, or is found out of order.
+     */
+    abstract public function assertLinesInOrder(TableNode $table);
+
+    /**
      * This method will check if all the fields exists and visible in the current page.
      *
      * @param  TableNode            $tableNode The id|name|title|alt|value of the input field

--- a/src/Behat/FlexibleMink/PseudoInterface/FlexibleContextInterface.php
+++ b/src/Behat/FlexibleMink/PseudoInterface/FlexibleContextInterface.php
@@ -9,6 +9,7 @@ use Behat\Mink\Exception\ElementNotFoundException;
 use Behat\Mink\Exception\ExpectationException;
 use Behat\Mink\Exception\UnsupportedDriverActionException;
 use Behat\Mink\Session;
+use InvalidArgumentException;
 
 /**
  * Pseudo interface for tracking the methods of the FlexibleContext.
@@ -92,8 +93,9 @@ trait FlexibleContextInterface
     /**
      * Checks that the page contains the given lines of text in the order specified.
      *
-     * @param  TableNode            $table A list of text lines to look for.
-     * @throws ExpectationException if a line is not found, or is found out of order.
+     * @param  TableNode                $table A list of text lines to look for.
+     * @throws ExpectationException     if a line is not found, or is found out of order.
+     * @throws InvalidArgumentException if the list of lines has more than one column.
      */
     abstract public function assertLinesInOrder(TableNode $table);
 


### PR DESCRIPTION
```html
This comes first<br>
This comes second<br>
This comes third
```

```gherkin
Then I should see the following lines in order:
  | This comes first  |
  | This comes third  |
  | This comes second |
  Line 'This comes second' came before its expected predecessor (Behat\Mink\Exception\ExpectationException)
```