### PR TITLE
Added assertion to check visible checkbox

### DIFF
--- a/src/Behat/FlexibleMink/Context/FlexibleContext.php
+++ b/src/Behat/FlexibleMink/Context/FlexibleContext.php
@@ -68,6 +68,14 @@ class FlexibleContext extends MinkContext
     /**
      * {@inheritdoc}
      */
+    public function checkOption($locator)
+    {
+        $this->assertVisibleOption($locator)->check();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function assertVisibleLink($locator)
     {
         $locator = $this->fixStepArgument($locator);
@@ -91,6 +99,34 @@ class FlexibleContext extends MinkContext
         }
 
         throw new ExpectationException("No visible link found for '$locator'", $this->getSession());
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function assertVisibleOption($locator)
+    {
+        $locator = $this->fixStepArgument($locator);
+
+        $options = $this->getSession()->getPage()->findAll(
+            'named',
+            ['field', $this->getSession()->getSelectorsHandler()->xpathLiteral($locator)]
+        );
+
+        /** @var NodeElement $option */
+        foreach ($options as $option) {
+            try {
+                $visible = $option->isVisible();
+            } catch (UnsupportedDriverActionException $e) {
+                return $option;
+            }
+
+            if ($visible) {
+                return $option;
+            }
+        }
+
+        throw new ExpectationException("No visible option found for '$locator'", $this->getSession());
     }
 
     /**

--- a/src/Behat/FlexibleMink/PseudoInterface/FlexibleContextInterface.php
+++ b/src/Behat/FlexibleMink/PseudoInterface/FlexibleContextInterface.php
@@ -62,6 +62,16 @@ trait FlexibleContextInterface
     abstract public function clickLink($locator);
 
     /**
+     * Clicks a visible checkbox with specified id|title|alt|text.
+     *
+     * This method overrides the MinkContext::checkOption() default behavior for checkOption to ensure that only visible
+     * options are checked.
+     * @see MinkContext::checkOption
+     * @param string $locator The id|title|alt|text of the option to be clicked.
+     */
+    abstract public function checkOption($locator);
+
+    /**
      * Finds the first matching visible link on the page.
      *
      * Warning: Will return the first link if the driver does not support visibility checks.
@@ -71,6 +81,17 @@ trait FlexibleContextInterface
      * @return NodeElement          The link.
      */
     abstract public function assertVisibleLink($locator);
+
+    /**
+     * Finds the first matching visible option on the page.
+     *
+     * Warning: Will return the first option if the driver does not support visibility checks.
+     *
+     * @param  string               $locator The option name.
+     * @throws ExpectationException If a visible option was not found.
+     * @return NodeElement          The option.
+     */
+    abstract public function assertVisibleOption($locator);
 
     /**
      * Checks that the page contains a visible input field and then returns it.


### PR DESCRIPTION
MinkContext checks the first named checkbox ignoring visibility, now it checks the first visible checkbox on the page.