### PR TITLE
Overriding Mink press button for visibility

### DIFF
--- a/src/Behat/FlexibleMink/Context/FlexibleContext.php
+++ b/src/Behat/FlexibleMink/Context/FlexibleContext.php
@@ -77,6 +77,34 @@ class FlexibleContext extends MinkContext
     /**
      * {@inheritdoc}
      */
+    public function assertVisibleButton($locator)
+    {
+        $locator = $this->fixStepArgument($locator);
+
+        $buttons = $this->getSession()->getPage()->findAll(
+            'named',
+            ['button', $this->getSession()->getSelectorsHandler()->xpathLiteral($locator)]
+        );
+
+        /** @var NodeElement $button */
+        foreach ($buttons as $button) {
+            try {
+                $visible = $button->isVisible();
+            } catch (UnsupportedDriverActionException $e) {
+                return $button;
+            }
+
+            if ($visible) {
+                return $button;
+            }
+        }
+
+        throw new ExpectationException("No visible button found for '$locator'", $this->getSession());
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function assertVisibleLink($locator)
     {
         $locator = $this->fixStepArgument($locator);
@@ -313,6 +341,14 @@ class FlexibleContext extends MinkContext
         $this->attachFileToField($field, $remotePath);
 
         unlink($tempZip);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function pressButton($locator)
+    {
+        $this->assertVisibleButton($locator);
     }
 
     /**

--- a/src/Behat/FlexibleMink/Context/FlexibleContext.php
+++ b/src/Behat/FlexibleMink/Context/FlexibleContext.php
@@ -81,10 +81,7 @@ class FlexibleContext extends MinkContext
     {
         $locator = $this->fixStepArgument($locator);
 
-        $buttons = $this->getSession()->getPage()->findAll(
-            'named',
-            ['button', $this->getSession()->getSelectorsHandler()->xpathLiteral($locator)]
-        );
+        $buttons = $this->getSession()->getPage()->findAll('named', ['button', $locator]);
 
         /** @var NodeElement $button */
         foreach ($buttons as $button) {

--- a/src/Behat/FlexibleMink/Context/FlexibleContext.php
+++ b/src/Behat/FlexibleMink/Context/FlexibleContext.php
@@ -89,12 +89,10 @@ class FlexibleContext extends MinkContext
         /** @var NodeElement $button */
         foreach ($buttons as $button) {
             try {
-                $visible = $button->isVisible();
+                if ($button->isVisible()) {
+                    return $button;
+                }
             } catch (UnsupportedDriverActionException $e) {
-                return $button;
-            }
-
-            if ($visible) {
                 return $button;
             }
         }
@@ -348,7 +346,7 @@ class FlexibleContext extends MinkContext
      */
     public function pressButton($locator)
     {
-        $this->assertVisibleButton($locator);
+        $this->assertVisibleButton($locator)->press();
     }
 
     /**

--- a/src/Behat/FlexibleMink/PseudoInterface/FlexibleContextInterface.php
+++ b/src/Behat/FlexibleMink/PseudoInterface/FlexibleContextInterface.php
@@ -73,6 +73,17 @@ trait FlexibleContextInterface
     abstract public function checkOption($locator);
 
     /**
+     * Finds the first matching visible button on the page.
+     *
+     * Warning: Will return the first button if the driver does not support visibility checks.
+     *
+     * @param  string               $locator The button name.
+     * @throws ExpectationException If a visible button was not found.
+     * @return NodeElement          The button.
+     */
+    abstract public function assertVisibleButton($locator);
+
+    /**
      * Finds the first matching visible link on the page.
      *
      * Warning: Will return the first link if the driver does not support visibility checks.
@@ -155,6 +166,18 @@ trait FlexibleContextInterface
      * @param string $path  The local path of the file
      */
     abstract public function addLocalFileToField($field, $path);
+
+    /**
+     * Presses the visible button with specified id|name|title|alt|value.
+     *
+     * This method overrides the MinkContext::pressButton() default behavior for pressButton to ensure that only visible
+     * buttons are pressed.
+     * @see MinkContext::pressButton
+     * @param string $button button id, inner text, value or alt
+     * @throws ExpectationException If a visible button field is not found.
+
+     */
+    abstract public function pressButton($button);
 
     /**
      * Scrolls the window to the top or bottom of the page body.

--- a/src/Behat/FlexibleMink/PseudoInterface/FlexibleContextInterface.php
+++ b/src/Behat/FlexibleMink/PseudoInterface/FlexibleContextInterface.php
@@ -172,10 +172,10 @@ trait FlexibleContextInterface
      *
      * This method overrides the MinkContext::pressButton() default behavior for pressButton to ensure that only visible
      * buttons are pressed.
+     *
      * @see MinkContext::pressButton
-     * @param string $button button id, inner text, value or alt
+     * @param  string               $button button id, inner text, value or alt
      * @throws ExpectationException If a visible button field is not found.
-
      */
     abstract public function pressButton($button);
 


### PR DESCRIPTION
Default behaviour now is to press only on buttons that are visible on the DOM.