### PR TITLE
Store converts spaces to snake case when injecting stored values.

### DIFF
--- a/src/Behat/FlexibleMink/Context/StoreContext.php
+++ b/src/Behat/FlexibleMink/Context/StoreContext.php
@@ -99,7 +99,7 @@ trait StoreContext
         preg_match_all('/\(the ([^\)]+) of the ([^\)]+)\)/', $string, $matches);
         foreach ($matches[0] as $i => $match) {
             $thingName = $matches[2][$i];
-            $thingProperty = $matches[1][$i];
+            $thingProperty = str_replace(' ', '_', strtolower($matches[1][$i]));
 
             if (!$thing = $this->get($thingName)) {
                 throw new Exception("Did not find $thingName in the store");


### PR DESCRIPTION
Requirement:
To be able to write feature files where the injected values are referred to in plain english, instead of
their snake case. e.g.

Before:
`Then I should see (the requisition_number of the order)`

After:
`Then I should see (the requisition number of the order)` or `Then I should see (the Requisition Number of the Order)`