### PR TITLE
Store can be initialized via onStoreInitialized()

### DIFF
--- a/src/Behat/FlexibleMink/Context/StoreContext.php
+++ b/src/Behat/FlexibleMink/Context/StoreContext.php
@@ -24,6 +24,10 @@ trait StoreContext
     public function clearRegistry()
     {
         $this->registry = [];
+
+        if (method_exists($this, 'onStoreInitialized')) {
+            $this->onStoreInitialized();
+        }
     }
 
     /**


### PR DESCRIPTION
The store resets the registry at the beginning of each scenario, but
I have a requirement where my Scenario's need access to something in
the store at all times.

To facilitate this, I added a check for an onStoreInitialized method
after the registry is cleared, and if it exists, the StoreContext will
call it to populate the newly cleared registry.