### PR TITLE
Fix float casting only capturing whole number.

### DIFF
--- a/src/Behat/FlexibleMink/Context/TypeCaster.php
+++ b/src/Behat/FlexibleMink/Context/TypeCaster.php
@@ -22,7 +22,7 @@ trait TypeCaster
     /**
      * Casts a step argument from a string to a float.
      *
-     * @Transform /^(\d*)\.(\d+)$/
+     * @Transform /^\d*\.\d+$/
      * @param  string $string the string to cast.
      * @return float  The resulting float.
      */


### PR DESCRIPTION
The `@Transform` for floats regex had two capturing groups, which caused only the first to be passed to the transformer. This meant that only the digits to the left of the decimal place were used when converting the string to a float. e.g. 1.99 became 1.

I removed the capturing groups from the regex as they were not needed. Without them, the entire string is passed to the transformer.