### PR TITLE
extract assert page address interface to MinkContextInterface

### DIFF
--- a/src/Behat/FlexibleMink/PseudoInterface/MinkContextInterface.php
+++ b/src/Behat/FlexibleMink/PseudoInterface/MinkContextInterface.php
@@ -56,7 +56,7 @@ trait MinkContextInterface
     /**
      * Checks, that current page PATH is equal to specified.
      *
-     * @param string $page.
+     * @param string $page The path of the path to get asserted.
      */
     abstract public function assertPageAddress($page);
 }

--- a/src/Behat/FlexibleMink/PseudoInterface/MinkContextInterface.php
+++ b/src/Behat/FlexibleMink/PseudoInterface/MinkContextInterface.php
@@ -52,4 +52,11 @@ trait MinkContextInterface
      * @param string $page The URL to visit.
      */
     abstract public function visit($page);
+
+    /**
+     * Checks, that current page PATH is equal to specified.
+     *
+     * @param string $page.
+     */
+    abstract public function assertPageAddress($page);
 }


### PR DESCRIPTION
As the title describes, this is used to extract the interface for the `assertPageAddress($page)` function.