### PR TITLE
Inject stored values in assertLinesInOrder

### DIFF
--- a/features/assertLinesInOrder.feature
+++ b/features/assertLinesInOrder.feature
@@ -1,0 +1,13 @@
+Feature: Assert Lines in Order
+  In order to ensure that content appears in the correct order
+  As a developer
+  I should have flexible line order assertions
+
+  Background:
+    Given I am on "/order.html"
+
+    Scenario: Step passes if lines are in the expected order
+      Then I should see the following lines in order:
+         | Line one   |
+         | Line two   |
+         | Line three |

--- a/features/assertLinesInOrder.feature
+++ b/features/assertLinesInOrder.feature
@@ -11,3 +11,13 @@ Feature: Assert Lines in Order
          | Line one   |
          | Line two   |
          | Line three |
+
+    Scenario: Step injects values properly
+      Given the following is stored as "list":
+          | first_entry  | Line one   |
+          | second_entry | Line two   |
+          | third_entry  | Line three |
+       Then I should see the following lines in order:
+          | (the first entry of the list)  |
+          | (the second entry of the list) |
+          | (the third entry of the list)  |

--- a/features/bootstrap/FeatureContext.php
+++ b/features/bootstrap/FeatureContext.php
@@ -1,7 +1,19 @@
 <?php
 
 use Behat\FlexibleMink\Context\FlexibleContext;
+use Behat\Gherkin\Node\TableNode;
 
 class FeatureContext extends FlexibleContext
 {
+    /**
+     * Places an object with the given structure into the store.
+     *
+     * @Given the following is stored as :key:
+     * @param string    $key        The key to put the object into the store under.
+     * @param TableNode $attributes The attributes of the object to create.
+     */
+    public function putStoreStep($key, TableNode $attributes)
+    {
+        $this->put((object) ($attributes->getRowsHash()), $key);
+    }
 }

--- a/src/Behat/FlexibleMink/Context/FlexibleContext.php
+++ b/src/Behat/FlexibleMink/Context/FlexibleContext.php
@@ -238,6 +238,8 @@ class FlexibleContext extends MinkContext
         $lastPosition = -1;
 
         foreach ($lines as $line) {
+            $line = $this->injectStoredValues($line);
+
             $position = strpos($page, $line);
 
             if ($position === false) {

--- a/web/order.html
+++ b/web/order.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <meta charset="UTF-8">
+        <title>Ordering test for FlexibleMink</title>
+    </head>
+    <body>
+    <ul>
+        <li>Line one</li>
+        <li>Line two</li>
+        <li>Line three</li>
+    </ul>
+    </body>
+</html>


### PR DESCRIPTION
Allows the feature file to make fewer assumptions when writing scenarios, e.g.:

```gherkin
Then I should see the following lines in order:
  | (the comment of the new followup) |
  | (the comment of the old followup) |
```