### PR TITLE
Extracting part that generates full URL into it's own method so that …

### DIFF
--- a/src/Behat/FlexibleMink/Context/WebDownloadContext.php
+++ b/src/Behat/FlexibleMink/Context/WebDownloadContext.php
@@ -25,8 +25,14 @@ trait WebDownloadContext
      */
     public function downloadViaLink($locator, $key = 'Download', $headers = '')
     {
-        $link = $this->assertVisibleLink($locator)->getAttribute('href');
+        $this->download($this->getFullUrl($this->assertVisibleLink($locator)->getAttribute('href')), $key, $headers);
+    }
 
+    /**
+     * {@inheritdoc}
+     */
+    public function getFullUrl($link)
+    {
         if (!preg_match(self::$baseUrlRegExp, $link)) {
             $currentUrl = $this->getSession()->getCurrentUrl();
 
@@ -44,7 +50,7 @@ trait WebDownloadContext
             }
         }
 
-        $this->download($link, $key, $headers);
+        return $link;
     }
 
     /**

--- a/src/Behat/FlexibleMink/PseudoInterface/WebDownloadContextInterface.php
+++ b/src/Behat/FlexibleMink/PseudoInterface/WebDownloadContextInterface.php
@@ -24,4 +24,13 @@ trait WebDownloadContextInterface
      * @param string $headersString Headers to pass with the curl request.
      */
     abstract public function download($file, $key = 'Download', $headersString = '');
+
+    /**
+     * Generates a url with a base url.  If none is specified, current url is used.
+     *
+     * @param  string               $link url string to determine url with base for.
+     * @throws ExpectationException If Base url could not be generated.
+     * @return string
+     */
+    abstract public function getBaseUrl($link);
 }


### PR DESCRIPTION
Extracting part of method which generates full URL of an item. 

For example: 

```html
<a href="/testing.php">Testing</a>
<!-- Not sure if the site below is real this is just for demonstration purposes...Not responsible for any material encountered -->
<a href="https://www.flexiblemink.com/testing>Testing</a>
```

With this, both of these href attributes would generate a full URL in the case of the first example, the current url would be used so if a person is on `https://www.stdcheck.com/adslkjfsl`

the url would be https://www.stdcheck.com/testing.php

The second example should just generate what is passed in as is since it's a full path already.