### PR TITLE
Fix parallel runner not distributing properly after scenario outlines

### DIFF
--- a/src/Behat/ParallelWorker/Filter/ParallelWorkerFilter.php
+++ b/src/Behat/ParallelWorker/Filter/ParallelWorkerFilter.php
@@ -32,28 +32,22 @@ class ParallelWorkerFilter extends SimpleFilter
      */
     private function filterExampleNode(ExampleTableNode $examples)
     {
-        // $offset represents the index of the first element in the table we would collect for this node
-        $curr = $this->curScenario % $this->totalNodes;
-        $offset = ($this->totalNodes - $curr) % $this->totalNodes;
+        $table = $examples->getTable();
+        $newExamples = [];
 
-        // get the examples as array and pull off the first row (which are the headers)
-        $table = array_values($examples->getTable());
-        $filteredTable = [array_shift($table)];
-
-        // if the table is long enough, then grab an example
-        if ($offset < count($table)) {
-            for ($i = $offset; $i < count($table); $i += $this->totalNodes) {
-                $filteredTable[] = $table[$i];
+        foreach ($table as $lineNum => $example) {
+            // Add the header (first row) automatically, then add the examples that we should run.
+            if (!count($newExamples) || $this->curScenario++ % $this->totalNodes == 0) {
+                $newExamples[$lineNum] = $example;
             }
-        } else {
-            // technically we don't HAVE to throw an exception here, because this is to a certain extent expected
-            // but its nice because now @return can just be ExampleTableNode
+        }
+
+        if (count($newExamples) == 1) {
+            // All we got was the header.
             throw new RuntimeException('No examples will run on this node!');
         }
 
-        $this->curScenario += count($table);
-
-        return new ExampleTableNode($filteredTable, $examples->getKeyword());
+        return new ExampleTableNode($newExamples, $examples->getKeyword());
     }
 
     /**

--- a/tests/Behat/ParallelWorker/Filter/FilterTest.php
+++ b/tests/Behat/ParallelWorker/Filter/FilterTest.php
@@ -68,6 +68,10 @@ Feature: Long feature with outline
       | act#1  | out#1   |
       | act#2  | out#2   |
       | act#3  | out#3   |
+
+  Scenario: Scenario#3 HD Remix
+    When HDAction occurs
+    Then HDOutcome should be visible
 GHERKIN;
     }
 

--- a/tests/Behat/ParallelWorker/Filter/ParallelWorkerFilterTest.php
+++ b/tests/Behat/ParallelWorker/Filter/ParallelWorkerFilterTest.php
@@ -97,7 +97,7 @@ class ParallelWorkerFilterTest extends FilterTest
         $feature = $filter->filterFeature($this->getParsedFeature());
         $scenarios = $feature->getScenarios();
 
-        $this->assertEquals(count($scenarios), 3);
+        $this->assertEquals(count($scenarios), 4);
         $this->assertEquals('Scenario#1', $scenarios[0]->getTitle());
         $this->assertEquals('Scenario#2', $scenarios[1]->getTitle());
         $this->assertEquals('Scenario#3', $scenarios[2]->getTitle());
@@ -109,6 +109,8 @@ class ParallelWorkerFilterTest extends FilterTest
             ['action' => 'act#2', 'outcome' => 'out#2'],
             ['action' => 'act#3', 'outcome' => 'out#3'],
         ], $scenarios[2]->getExampleTable()->getColumnsHash());
+
+        $this->assertEquals('Scenario#3 HD Remix', $scenarios[3]->getTitle());
     }
 
     /**
@@ -141,7 +143,7 @@ class ParallelWorkerFilterTest extends FilterTest
         $feature = $filter->filterFeature($this->getParsedFeature());
         $scenarios = $feature->getScenarios();
 
-        $this->assertEquals(count($scenarios), 2);
+        $this->assertEquals(count($scenarios), 3);
         $this->assertEquals('Scenario#2', $scenarios[0]->getTitle());
         $this->assertEquals('Scenario#3', $scenarios[1]->getTitle());
 
@@ -150,6 +152,8 @@ class ParallelWorkerFilterTest extends FilterTest
         $this->assertEquals([
             ['action' => 'act#2', 'outcome' => 'out#2'],
         ], $scenarios[1]->getExampleTable()->getColumnsHash());
+
+        $this->assertEquals('Scenario#3 HD Remix', $scenarios[2]->getTitle());
     }
 
     /**
@@ -198,7 +202,7 @@ class ParallelWorkerFilterTest extends FilterTest
         $feature = $filter->filterFeature($this->getParsedFeature());
         $scenarios = $feature->getScenarios();
 
-        $this->assertEquals(count($scenarios), 1);
+        $this->assertEquals(count($scenarios), 2);
         $this->assertEquals('Scenario#3', $scenarios[0]->getTitle());
 
         $this->assertTrue($scenarios[0] instanceof OutlineNode);
@@ -206,6 +210,8 @@ class ParallelWorkerFilterTest extends FilterTest
         $this->assertEquals([
             ['action' => 'act#1', 'outcome' => 'out#1'],
         ], $scenarios[0]->getExampleTable()->getColumnsHash());
+
+        $this->assertEquals('Scenario#3 HD Remix', $scenarios[1]->getTitle());
     }
 
     /**
@@ -237,8 +243,9 @@ class ParallelWorkerFilterTest extends FilterTest
         $feature = $filter->filterFeature($this->getParsedFeature());
         $scenarios = $feature->getScenarios();
 
-        $this->assertEquals(count($scenarios), 1);
+        $this->assertEquals(count($scenarios), 2);
         $this->assertEquals('Scenario#2', $scenarios[0]->getTitle());
+        $this->assertEquals('Scenario#3 HD Remix', $scenarios[1]->getTitle());
 
         /*****************
          *    Node 3    *


### PR DESCRIPTION
**Method:**
- Run a set of tests with a scenario outline on more nodes than the outline has examples

**Expected Behavior:**
- All of the tests should run, distributed properly among the nodes
- Line numbers for examples should be accurate in case of test failure

**Actual Result:**
- Tests after the outline aren't all run, and some are run on multiple nodes
- The line numbers for examples were incorrect

**Cause:**
- The scenario count was not incremented if no examples were being run for an outline on a particular node, because an exception was thrown before the increment call
- The original array used the line numbers as the key for each example, and the filter was using array_values which discarded them

**Solution:**
Rewrote `filterExampleNode` to preserve array keys (to fix the line issue) and step through each example while continually incrementing the counter (which fixes the distribution issue)