### PR TITLE
Assert Field Contains with Waitfor

### DIFF
--- a/features/assertFieldContains.feature
+++ b/features/assertFieldContains.feature
@@ -1,0 +1,9 @@
+Feature: Assert Field Contains
+  In order to test content inside a field
+  As a developer
+  I should have a waitfor on the assertion
+
+ Scenario: Developer can test for asserting a field that is updated with a delay
+    When I am on "/assert-field-contains.html"
+    When I press "Fill in delayed field with a delay"
+    Then the "Delayed field" field should contain "delayed value"

--- a/features/assertFieldContains.feature
+++ b/features/assertFieldContains.feature
@@ -5,5 +5,5 @@ Feature: Assert Field Contains
 
  Scenario: Developer can test for asserting a field that is updated with a delay
     When I am on "/assert-field-contains.html"
-    When I press "Fill in delayed field with a delay"
+     And I press "Fill in delayed field with a delay"
     Then the "Delayed field" field should contain "delayed value"

--- a/src/Behat/FlexibleMink/Context/FlexibleContext.php
+++ b/src/Behat/FlexibleMink/Context/FlexibleContext.php
@@ -41,6 +41,19 @@ class FlexibleContext extends MinkContext
     /**
      * {@inheritdoc}
      */
+    public function assertFieldContains($field, $value)
+    {
+        $field = $this->fixStepArgument($field);
+        $value = $this->fixStepArgument($value);
+
+        $this->waitFor(function () use ($field, $value) {
+            parent::assertFieldContains($field, $value);
+        });
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function assertPageContainsText($text)
     {
         $text = $this->injectStoredValues($text);

--- a/src/Behat/FlexibleMink/Context/FlexibleContext.php
+++ b/src/Behat/FlexibleMink/Context/FlexibleContext.php
@@ -43,9 +43,6 @@ class FlexibleContext extends MinkContext
      */
     public function assertFieldContains($field, $value)
     {
-        $field = $this->fixStepArgument($field);
-        $value = $this->fixStepArgument($value);
-
         $this->waitFor(function () use ($field, $value) {
             parent::assertFieldContains($field, $value);
         });

--- a/src/Behat/FlexibleMink/PseudoInterface/FlexibleContextInterface.php
+++ b/src/Behat/FlexibleMink/PseudoInterface/FlexibleContextInterface.php
@@ -26,6 +26,14 @@ trait FlexibleContextInterface
     abstract public function assertPageContainsText($text);
 
     /**
+     * This method overrides the MinkContext::assertPageContainsText() default behavior for assertFieldContains to
+     * ensure that it waits for the text to be available with a max time limit.
+     *
+     * @see MinkContext::assertFieldContains
+     */
+    abstract public function assertFieldContains($field, $value);
+
+    /**
      * Returns Mink session.
      *
      * @param  string|null $name name of the session OR active session will be used

--- a/src/Behat/FlexibleMink/PseudoInterface/FlexibleContextInterface.php
+++ b/src/Behat/FlexibleMink/PseudoInterface/FlexibleContextInterface.php
@@ -30,6 +30,8 @@ trait FlexibleContextInterface
      * ensure that it waits for the text to be available with a max time limit.
      *
      * @see MinkContext::assertFieldContains
+     * @throws ExpectationException If the field can't be found
+     * @throws ExpectationException If the field doesn't match the value
      */
     abstract public function assertFieldContains($field, $value);
 

--- a/web/assert-field-contains.html
+++ b/web/assert-field-contains.html
@@ -20,3 +20,4 @@
 </form>
 </body>
 </html>
+

--- a/web/assert-field-contains.html
+++ b/web/assert-field-contains.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Assert Field Contains Delayed Value</title>
+</head>
+<body>
+<form>
+    <h1>Assert Field Contains Delayed Value</h1>
+    <label for="delayed-field">Delayed field</label>
+    <input type="text" id="delayed-field">
+    <button type="button" onclick="fillDelayedFieldWithDelay()">Fill in delayed field with a delay</button>
+    <script>
+        function fillDelayedFieldWithDelay() {
+            setTimeout(function() {
+                document.getElementById("delayed-field").value = "delayed value"
+            }, 2000);
+        }
+    </script>
+</form>
+</body>
+</html>


### PR DESCRIPTION
Adds a wait for to the `assertFieldsContains` function for scenarios if Javascript changes the value of an input.

For https://github.com/Medology/healthlabs.com/pull/154