### PR TITLE
Adding waitFor for assertPageAddress with Feature Test

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -11,6 +11,7 @@ machine:
 dependencies:
   override:
     - sudo pip install docker-compose
+    - docker login -e ${DOCKER_EMAIL} -u ${DOCKER_USERNAME} -p ${DOCKER_PASSWORD}
     - docker-compose -p flexiblemink -f docker/docker-compose.yml up -d
     - sleep 5
     - bin/init_project

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -10,7 +10,7 @@ services:
       - 80:80
 
   chrome:
-    image: selenium/standalone-chrome-debug:2.53.0
+    image: medology/standalone-chrome-debug:2.53.0
     depends_on:
       - web
     environment:

--- a/features/FlexibleContext/assertPageAddress.feature
+++ b/features/FlexibleContext/assertPageAddress.feature
@@ -1,0 +1,16 @@
+Feature: Assert Page Address Method
+  In order to reliably check if I am on a page
+  As a developer
+  I need Behat to wait for the page to finish loading
+
+  Background:
+    Given I am on "/page-load-delay.html"
+
+  Scenario: Behat Waits for Page to Finish Loading
+    When I follow "Small Delay"
+    Then I should be on "/index.html"
+
+  Scenario: When Page Takes too Long, Behat Fails the Assertion
+    When I follow "Big Delay"
+     And I assert that I should be on "index.html"
+    Then the assertion should throw an ExpectationException

--- a/src/Behat/FlexibleMink/Context/FlexibleContext.php
+++ b/src/Behat/FlexibleMink/Context/FlexibleContext.php
@@ -51,6 +51,16 @@ class FlexibleContext extends MinkContext
     /**
      * {@inheritdoc}
      */
+    public function assertPageAddress($page)
+    {
+        $this->waitFor(function () use ($page) {
+            parent::assertPageAddress($page);
+        });
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function assertPageContainsText($text)
     {
         $text = $this->injectStoredValues($text);

--- a/src/Behat/FlexibleMink/PseudoInterface/FlexibleContextInterface.php
+++ b/src/Behat/FlexibleMink/PseudoInterface/FlexibleContextInterface.php
@@ -26,6 +26,14 @@ trait FlexibleContextInterface
     abstract public function assertPageContainsText($text);
 
     /**
+     * This method overrides the MinkContext::assertPageAddress() default behavior by adding a waitFor to ensure that
+     * Behat waits for the page to load properly before failing out.
+     *
+     * @param string $page The address of the page to load
+     */
+    abstract public function assertPageAddress($page);
+
+    /**
      * This method overrides the MinkContext::assertPageContainsText() default behavior for assertFieldContains to
      * ensure that it waits for the text to be available with a max time limit.
      *

--- a/web/page-load-delay.html
+++ b/web/page-load-delay.html
@@ -9,20 +9,23 @@
           // prevent the default click
           event.preventDefault();
 
-          // delay the click for 5 seconds
+          // delay the click for 2 seconds
           setTimeout(function() {
             location = $("#sml_delay").attr('href');
           }, 2000);
+
+          return false;
         });
 
         $("#big_delay").click(function() {
           // prevent the default click
           event.preventDefault();
 
-          // delay the click for 5 seconds
+          // delay the click for 7 seconds
           setTimeout(function() {
-            location = $("#sml_delay").attr('href');
+            location = $("#big_delay").attr('href');
           }, 7000);
+
           return false;
         });
       });

--- a/web/page-load-delay.html
+++ b/web/page-load-delay.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Page Load Delay</title>
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.1.0/jquery.min.js"></script>
+    <script type="text/javascript">
+      $(document).ready(function () {
+        $("#sml_delay").click(function(event) {
+          // prevent the default click
+          event.preventDefault();
+
+          // delay the click for 5 seconds
+          setTimeout(function() {
+            location = $("#sml_delay").attr('href');
+          }, 2000);
+        });
+
+        $("#big_delay").click(function() {
+          // prevent the default click
+          event.preventDefault();
+
+          // delay the click for 5 seconds
+          setTimeout(function() {
+            location = $("#sml_delay").attr('href');
+          }, 7000);
+          return false;
+        });
+      });
+    </script>
+  </head>
+  <body>
+    <h1>Page Load Delay</h1>
+    <p>This page creates a delay when loading another page via Javascript.</p>
+    <a href="index.html" id="sml_delay">Small Delay</a>
+    <a href="index.html" id="big_delay">Big Delay</a>
+  </body>
+</html>


### PR DESCRIPTION
# Overview

To fix some intermittent failures on stdcheck, we need to make sure that the `MinkContext::assertPageAddress` method actually waits a little to bit to see if you're on the page.

# Changes
```
FlexibleContext
```
- new method which wraps `MinkContext::assertPageAddress` in a `waitFor`

```
assertPageAddress.feature
page-load-delay.html
```
- html page adds delays to link clicks
- feature tests to make sure that Behat properly detects page change and fails when page change takes too long