### PR TITLE
Gherkin Regex Syntax Error and CircleCI Being a Pain

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -11,6 +11,7 @@ machine:
 dependencies:
   override:
     - sudo pip install docker-compose
+    - sudo pip install 'six==1.10.0'
     - docker login -e ${DOCKER_EMAIL} -u ${DOCKER_USERNAME} -p ${DOCKER_PASSWORD}
     - docker-compose -p flexiblemink -f docker/docker-compose.yml up -d
     - sleep 5

--- a/src/Behat/FlexibleMink/Context/TableContext.php
+++ b/src/Behat/FlexibleMink/Context/TableContext.php
@@ -348,8 +348,8 @@ trait TableContext
     /**
      * {@inheritdoc}
      *
-     * @Given /^the table (?P<name>"[^"]+") has (?P<val>"[^"]+") at \((?P<rIdx>\d+),(?P<cIdx>\d+)\) in the (?<piece>header|body|footer)$/
-     * @Then /^the table (?P<name>"[^"]+") should have (?P<val>"[^"]+") at \((?P<rIdx>\d+),(?P<cIdx>\d+)\) in the (?<piece>header|body|footer)$/
+     * @Given /^the table (?P<name>"[^"]+") has (?P<val>"[^"]+") at \((?P<rIdx>\d+),(?P<cIdx>\d+)\) in the (?P<piece>header|body|footer)$/
+     * @Then /^the table (?P<name>"[^"]+") should have (?P<val>"[^"]+") at \((?P<rIdx>\d+),(?P<cIdx>\d+)\) in the (?P<piece>header|body|footer)$/
      */
     public function assertCellValue($name, $val, $rIdx, $cIdx, $piece)
     {


### PR DESCRIPTION
### Problem
`Statement Parsing`
The Gherkin statement for checking if a particular cell in a table was not parsing correctly by the IDE. Instead of showing a valid statement as being valid, the IDE instead showed it as being invalid.

<img width="809" alt="screen shot 2016-09-10 at 12 24 48 pm" src="https://cloud.githubusercontent.com/assets/13357655/18412356/a6685cde-7751-11e6-8076-b731be556f79.png">

### Docker Dependency Failure
Also `docker-compose` randomly started failing on CircleCI. So fixing that too. So I can run tests again.

![screen shot 2016-09-10 at 4 13 23 pm](https://cloud.githubusercontent.com/assets/13357655/18413591/8d0ccaf2-7771-11e6-9e0e-31682335ee99.png)

# Cause
### Statement Parsing
In `TableContext::assertCellValue`, the regex for the Gherkin statement was malformed in referencing the variables match groups were to be assigned to.

As a result, the statement would *parse* correctly during runtime, but the IDE failed to recognize the statement as valid.

### Docker Dependency Failure
I honestly have no clue why this shit randomly blew up.

# Fix
### Statement Parsing
The regex statements in `TableContext::assertCellValue` were fixed and the IDE now properly recognizes the statements as valid.

### Docker Dependency Failure
Updated `circle.yml` to install the right version of the python six dependancy.