### PR TITLE
fix the anchor tag without href is not detected

### DIFF
--- a/features/FlexibleContext/AssertLinkClickable.feature
+++ b/features/FlexibleContext/AssertLinkClickable.feature
@@ -1,0 +1,18 @@
+Feature: Assert Link is clickable
+  In order to ensure that the link is clickable
+  As a developer
+  I should have link clickable assertion
+
+  Background:
+    Given I am on "/link.html"
+
+  Scenario: Step passes if link is clickable
+    Then I follow "I am a link"
+
+  Scenario: Step passes if link without href
+    Then I follow "an anchor tag without href"
+
+  Scenario: Step fails if link is invisible
+    When I assert that I follow "an invisible anchor tag"
+    Then the assertion should throw an ExpectationException
+     And the assertion should fail with the message "No visible link found for 'an invisible anchor tag'"

--- a/features/FlexibleContext/assertLinkVisible.feature
+++ b/features/FlexibleContext/assertLinkVisible.feature
@@ -1,0 +1,16 @@
+Feature: Assert Link is visible
+  In order to ensure that the link is visible
+  As a developer
+  I should have visible link assertion
+
+  Background:
+    Given I am on "/link.html"
+
+  Scenario: Step passes if links are visible
+    Then the "an anchor tag without href" link is visible
+     And the "an anchor tag with href" link is visible
+
+  Scenario: Step fails if link is invisible
+    When I assert that the "an invisible anchor tag" link is visible
+    Then the assertion should throw an ExpectationException
+     And the assertion should fail with the message "No visible link found for 'an invisible anchor tag'"

--- a/features/FlexibleContext/assertLinkVisible.feature
+++ b/features/FlexibleContext/assertLinkVisible.feature
@@ -6,9 +6,11 @@ Feature: Assert Link is visible
   Background:
     Given I am on "/link.html"
 
-  Scenario: Step passes if links are visible
+  Scenario: Step passes if link is visible
+    Then the "an anchor tag with href" link is visible
+
+  Scenario: Step passes if link without href is visible
     Then the "an anchor tag without href" link is visible
-     And the "an anchor tag with href" link is visible
 
   Scenario: Step fails if link is invisible
     When I assert that the "an invisible anchor tag" link is visible

--- a/features/FlexibleContext/assertLinkVisible.feature
+++ b/features/FlexibleContext/assertLinkVisible.feature
@@ -7,7 +7,7 @@ Feature: Assert Link is visible
     Given I am on "/link.html"
 
   Scenario: Step passes if link is visible
-    Then the "an anchor tag with href" link is visible
+    Then the "I am a link" link is visible
 
   Scenario: Step passes if link without href is visible
     Then the "an anchor tag without href" link is visible

--- a/src/Behat/FlexibleMink/Context/FlexibleContext.php
+++ b/src/Behat/FlexibleMink/Context/FlexibleContext.php
@@ -163,6 +163,9 @@ class FlexibleContext extends MinkContext
 
     /**
      * {@inheritdoc}
+     *
+     * @Given the :locator link is visible
+     * @Then the :locator link should be visible
      */
     public function assertVisibleLink($locator)
     {
@@ -170,11 +173,14 @@ class FlexibleContext extends MinkContext
 
         $links = $this->getSession()->getPage()->findAll(
             'named',
-            ['link', $this->getSession()->getSelectorsHandler()->xpathLiteral($locator)]
+            ['content', $this->getSession()->getSelectorsHandler()->xpathLiteral($locator)]
         );
 
         /** @var NodeElement $link */
         foreach ($links as $link) {
+            if ($link->getTagName() != 'a') {
+                continue;
+            }
             try {
                 $visible = $link->isVisible();
             } catch (UnsupportedDriverActionException $e) {

--- a/web/link.html
+++ b/web/link.html
@@ -4,6 +4,7 @@
     <title>Link for Flexible Mink</title>
   </head>
   <body>
+    <a href="#">I am a link</a>
     <a>an anchor tag without href</a>
     <a href="#">an anchor tag with href</a>
     <a style="display:none">an invisible anchor tag</a>

--- a/web/link.html
+++ b/web/link.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Link for Flexible Mink</title>
+  </head>
+  <body>
+    <a>an anchor tag without href</a>
+    <a href="#">an anchor tag with href</a>
+    <a style="display:none">an invisible anchor tag</a>
+  </body>
+</html>

--- a/web/link.html
+++ b/web/link.html
@@ -6,7 +6,6 @@
   <body>
     <a href="#">I am a link</a>
     <a>an anchor tag without href</a>
-    <a href="#">an anchor tag with href</a>
     <a style="display:none">an invisible anchor tag</a>
   </body>
 </html>


### PR DESCRIPTION
This fix the problem that Flexible mink can't detect anchor tag `<a>` when there is no `href` in the attribute.

_It is currently blocking the stdcheck my account redesign story_