### PR TITLE
Fix assertVisibleLink not Checking Title/Id/Rel/Alt

### DIFF
--- a/features/FlexibleContext/AssertLinkClickable.feature
+++ b/features/FlexibleContext/AssertLinkClickable.feature
@@ -6,13 +6,39 @@ Feature: Assert Link is clickable
   Background:
     Given I am on "/link.html"
 
-  Scenario: Step passes if link is clickable
-    Then I follow "I am a link"
+  Scenario: When Multiple Matches are Found, First Visible Match is Used
+    When I follow "Link"
 
-  Scenario: Step passes if link without href
-    Then I follow "an anchor tag without href"
+  Scenario Outline: Visible Links are Clickable
+    Then I follow "<locator>"
 
-  Scenario: Step fails if link is invisible
-    When I assert that I follow "an invisible anchor tag"
+    Examples:
+      | locator                   |
+      | Visible Text Link w/ Href |
+      | Visible Text Link no Href |
+      | id-visible-href           |
+      | id-visible-nohref         |
+      | title-visible-href        |
+      | title-visible-nohref      |
+      | rel-visible-href          |
+      | rel-visible-nohref        |
+      | alt-visible-href          |
+      | alt-visible-nohref        |
+
+  Scenario Outline: Trying to Click Invisible Link Throws Exception
+    When I assert that I follow "<locator>"
     Then the assertion should throw an ExpectationException
-     And the assertion should fail with the message "No visible link found for 'an invisible anchor tag'"
+     And the assertion should fail with the message "No visible link found for '<locator>'"
+
+    Examples:
+      | locator                     |
+      | Invisible Text Link w/ Href |
+      | Invisible Text Link no Href |
+      | id-invisible-href           |
+      | id-invisible-nohref         |
+      | title-invisible-href        |
+      | title-invisible-nohref      |
+      | rel-invisible-href          |
+      | rel-invisible-nohref        |
+      | alt-invisible-href          |
+      | alt-invisible-nohref        |

--- a/features/FlexibleContext/assertLinkVisible.feature
+++ b/features/FlexibleContext/assertLinkVisible.feature
@@ -6,13 +6,39 @@ Feature: Assert Link is visible
   Background:
     Given I am on "/link.html"
 
-  Scenario: Step passes if link is visible
-    Then the "I am a link" link is visible
+  Scenario: When Multiple Matches are Found, First Visible Match is Used
+    Then the "Text Link" link should be visible
 
-  Scenario: Step passes if link without href is visible
-    Then the "an anchor tag without href" link is visible
+  Scenario Outline: Visible Links Are Properly Found
+    Then the "<locator>" link is visible
 
-  Scenario: Step fails if link is invisible
-    When I assert that the "an invisible anchor tag" link is visible
+    Examples:
+      | locator                   |
+      | Visible Text Link w/ Href |
+      | Visible Text Link no Href |
+      | id-visible-href           |
+      | id-visible-nohref         |
+      | title-visible-href        |
+      | title-visible-nohref      |
+      | rel-visible-href          |
+      | rel-visible-nohref        |
+      | alt-visible-href          |
+      | alt-visible-nohref        |
+
+  Scenario Outline: Asserting Hidden Links are Visible Throws Exception
+    When I assert that the "<locator>" link is visible
     Then the assertion should throw an ExpectationException
-     And the assertion should fail with the message "No visible link found for 'an invisible anchor tag'"
+     And the assertion should fail with the message "No visible link found for '<locator>'"
+
+    Examples:
+      | locator                     |
+      | Invisible Text Link w/ Href |
+      | Invisible Text Link no Href |
+      | id-invisible-href           |
+      | id-invisible-nohref         |
+      | title-invisible-href        |
+      | title-invisible-nohref      |
+      | rel-invisible-href          |
+      | rel-invisible-nohref        |
+      | alt-invisible-href          |
+      | alt-invisible-nohref        |

--- a/web/link.html
+++ b/web/link.html
@@ -2,10 +2,39 @@
 <html>
   <head>
     <title>Link for Flexible Mink</title>
+    <style type="text/css">
+      .invisible {
+        display: none;
+      }
+    </style>
   </head>
   <body>
-    <a href="#">I am a link</a>
-    <a>an anchor tag without href</a>
-    <a style="display:none">an invisible anchor tag</a>
+    <a href="#" class="invisible">Link</a>
+
+    <a href="#">Visible Text Link w/ Href</a>
+    <a href="#" id="id-visible-href">Visible Id Link w/ Href</a>
+    <a href="#" title="title-visible-href">Visible Title Link w/ Href</a>
+    <a href="#" rel="rel-visible-href">Visible Rel Link w/ Href</a>
+    <a href="#"><img src="" alt="alt-visible-href" />Visible Alt Link w/ Href</a>
+
+    <a>Visible Text Link no Href</a>
+    <a id="id-visible-nohref">Visible Id Link no Href</a>
+    <a title="title-visible-nohref">Visible Title Link no Href</a>
+    <a rel="rel-visible-nohref">Visible Rel Link no Href</a>
+    <a><img src="" alt="alt-visible-nohref" />Visible Alt Link no Href</a>
+
+    <a href="#" class="invisible">Invisible Text Link w/ Href</a>
+    <a href="#" id="id-invisible-href" class="invisible">Invisible Id Link w/ Href</a>
+    <a href="#" title="title-invisible-href" class="invisible">Invisible Title Link w/ Href</a>
+    <a href="#" rel="rel-invisible-href" class="invisible">Invisible Rel Link w/ Href</a>
+    <a href="#" class="invisible"><img src="" alt="alt-invisible-href" />Invisible Alt Link w/ Href</a>
+
+    <a class="invisible">Invisible Text Link no Href</a>
+    <a id="id-invisible-nohref" class="invisible">Invisible Id Link no Href</a>
+    <a title="title-invisible-nohref" class="invisible">Invisible Title Link no Href</a>
+    <a rel="rel-invisible-nohref" class="invisible">Invisible Rel Link no Href</a>
+    <a class="invisible"><img src="" alt="alt-invisible-nohref" />Invisible Alt Link no Href</a>
+
+    <
   </body>
 </html>


### PR DESCRIPTION
# Overview

As a part of #69, @johnnie502 updated FlexibleMink to also detect anchor tags which don't have the `href` attribute (as this is quite common in Angular). Unfortunately the implementation only allowed matching on text content of the anchor tag. The default behavior of Mink allowed matching on the `id`, `rel`, `title`, `text()`, and `alt` (for images inside `a`) properties.

# Changes

To allow a clean port of this method into stdcheck, I'm updating the `assertVisibleLink` to use the named `link` selector, but just without the `href`.

It's hacky, since it modifies the default link selector's xpath via regex, but this is because the `replacements` and `selectors` properties used in the `NameSelector` are private and cannot be accessed. Maybe there's a way around that, but I didn't see it.