### PR TITLE
Assert page contains texts

### DIFF
--- a/features/FlexibleContext/assertTexts.feature
+++ b/features/FlexibleContext/assertTexts.feature
@@ -12,19 +12,19 @@ Feature: Assert Page Contains Texts
       | Line two   |
       | Line three |
 
-    Scenario: Step injects values properly
-      Given the following is stored as "list":
-          | first_entry  | Line one   |
-          | second_entry | Line two   |
-          | third_entry  | Line three |
-       Then I should see the following:
-          | (the first entry of the list)  |
-          | (the second entry of the list) |
-          | (the third entry of the list)  |
+  Scenario: Step injects values properly
+    Given the following is stored as "list":
+      | first_entry  | Line one   |
+      | second_entry | Line two   |
+      | third_entry  | Line three |
+     Then I should see the following:
+      | (the first entry of the list)  |
+      | (the second entry of the list) |
+      | (the third entry of the list)  |
 
-    Scenario: Assertion fails reliably if a given line is not present
-      When I assert that I should see the following:
-         | Line two |
-         | Megatron |
-      Then the assertion should throw an ResponseTextException
-       And the assertion should fail with the message 'The text "Megatron" was not found anywhere in the text of the current page.'
+  Scenario: Assertion fails reliably if a given line is not present
+    When I assert that I should see the following:
+     | Line two |
+     | Megatron |
+    Then the assertion should throw an ResponseTextException
+     And the assertion should fail with the message 'The text "Megatron" was not found anywhere in the text of the current page.'

--- a/features/FlexibleContext/assertTexts.feature
+++ b/features/FlexibleContext/assertTexts.feature
@@ -1,0 +1,30 @@
+Feature: Assert Page Contains Texts
+  In order to ensure that multiple texts appear in a page
+  As a developer
+  I should be able to assert multiple texts in one step
+
+  Background:
+    Given I am on "/order.html"
+
+  Scenario: Step passes if lines are present
+    Then I should see the following:
+      | Line one   |
+      | Line two   |
+      | Line three |
+
+    Scenario: Step injects values properly
+      Given the following is stored as "list":
+          | first_entry  | Line one   |
+          | second_entry | Line two   |
+          | third_entry  | Line three |
+       Then I should see the following:
+          | (the first entry of the list)  |
+          | (the second entry of the list) |
+          | (the third entry of the list)  |
+
+    Scenario: Assertion fails reliably if a given line is not present
+      When I assert that I should see the following:
+         | Line two |
+         | Megatron |
+      Then the assertion should throw an ResponseTextException
+       And the assertion should fail with the message 'The text "Megatron" was not found anywhere in the text of the current page.'

--- a/src/Behat/FlexibleMink/Context/FlexibleContext.php
+++ b/src/Behat/FlexibleMink/Context/FlexibleContext.php
@@ -86,7 +86,6 @@ class FlexibleContext extends MinkContext
         }
     }
 
-
     /**
      * {@inheritdoc}
      */

--- a/src/Behat/FlexibleMink/Context/FlexibleContext.php
+++ b/src/Behat/FlexibleMink/Context/FlexibleContext.php
@@ -72,6 +72,23 @@ class FlexibleContext extends MinkContext
 
     /**
      * {@inheritdoc}
+     *
+     * @Then I should see the following:
+     */
+    public function assertPageContainsTexts(TableNode $table)
+    {
+        if (count($table->getRow(0)) > 1) {
+            throw new InvalidArgumentException('Arguments must be a single-column list of items');
+        }
+
+        foreach ($table->getRows() as $text) {
+            $this->assertPageContainsText($text[0]);
+        }
+    }
+
+
+    /**
+     * {@inheritdoc}
      */
     public function assertPageNotContainsText($text)
     {

--- a/src/Behat/FlexibleMink/PseudoInterface/FlexibleContextInterface.php
+++ b/src/Behat/FlexibleMink/PseudoInterface/FlexibleContextInterface.php
@@ -7,6 +7,7 @@ use Behat\Mink\Element\NodeElement;
 use Behat\Mink\Exception\DriverException;
 use Behat\Mink\Exception\ElementNotFoundException;
 use Behat\Mink\Exception\ExpectationException;
+use Behat\Mink\Exception\ResponseTextException;
 use Behat\Mink\Exception\UnsupportedDriverActionException;
 use Behat\Mink\Session;
 use InvalidArgumentException;
@@ -24,6 +25,14 @@ trait FlexibleContextInterface
      * @param string $text Text to be searched in the page.
      */
     abstract public function assertPageContainsText($text);
+
+    /**
+     * Asserts that the page contains a list of strings.
+     *
+     * @param  TableNode             $table The list of strings to find.
+     * @throws ResponseTextException If the text is not found.
+     */
+    abstract public function assertPageContainsTexts(TableNode $table);
 
     /**
      * This method overrides the MinkContext::assertPageAddress() default behavior by adding a waitFor to ensure that


### PR DESCRIPTION
As part of the better lab redesign, I added a method to `WebContext` that @johnnie502 [suggested was more appropriate in FlexbileMink](https://github.com/Medology/stdcheck.com/pull/1581#pullrequestreview-763451).

This new method can be used to assert that multiple strings occur in a single page, regardless of the order, in a single step, rather than specifying thus:

```
Then I should see "string1"
 And I should see "string2"
 And I should see "string3"
```

With this new method, it can be specified this way:

```
Then I should see the following:
  | string1 |
  | string2 |
  | string3 |
```

This is a little easier to read, and useful if you have already specified a list of data earlier in a scenario.