### PR TITLE
Fixing InjectStoredValues to Handle Magic Properties

### DIFF
--- a/bin/phpunit
+++ b/bin/phpunit
@@ -1,3 +1,3 @@
 #!/bin/bash +x
 
-docker run -v $(pwd):/data -w /data --rm phpunit/phpunit:5.5.0 --configuration=phpunit.xml $@
+php ./vendor/phpunit/phpunit/phpunit --configuration=phpunit.xml $@

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -14,6 +14,7 @@
             <directory suffix=".php">./tests/Behat/ParallelWorker</directory>
         </testsuite>
         <testsuite name="Flexible Mink Context Tests">
+            <directory suffix=".php">./tests/Behat/DefaultMocks</directory>
             <directory suffix=".php">./tests/Behat/FlexibleMink/Context</directory>
         </testsuite>
     </testsuites>

--- a/src/Behat/FlexibleMink/Context/StoreContext.php
+++ b/src/Behat/FlexibleMink/Context/StoreContext.php
@@ -123,8 +123,8 @@ trait StoreContext
             }
 
             if (
-                (is_object($thing) && !property_exists($thing, $thingProperty)) ||
-                (is_array($thing) && !isset($thing, $thingProperty))
+                (is_object($thing) && !isset($thing->$thingProperty)) ||
+                (is_array($thing) && !isset($thing[$thingProperty]))
             ) {
                 throw new Exception("$thingName does not have a $thingProperty property");
             }

--- a/tests/Behat/DefaultMocks/MagicMethods.php
+++ b/tests/Behat/DefaultMocks/MagicMethods.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Tests\Behat\DefaultMocks;
+
+class MagicMethods
+{
+    public function __get($name)
+    {
+    }
+
+    public function __set($name, $value)
+    {
+    }
+
+    public function __isset($name)
+    {
+    }
+
+    public function __unset($name)
+    {
+    }
+
+    public function __call($method, $arguments)
+    {
+    }
+
+    public function __toString()
+    {
+    }
+}

--- a/tests/Behat/FlexibleMink/Context/StoreContextTest.php
+++ b/tests/Behat/FlexibleMink/Context/StoreContextTest.php
@@ -5,6 +5,7 @@ use Exception;
 use PHPUnit\Framework\TestCase;
 use PHPUnit_Framework_Error_Warning;
 use stdClass;
+use Tests\Behat\DefaultMocks\MagicMethods;
 use TypeError;
 
 class StoreContextTest extends TestCase
@@ -44,7 +45,6 @@ class StoreContextTest extends TestCase
 
         $testObj = $this->getMockObject();
         $name = 'testObj';
-
         $this->put($testObj, $name);
 
 
@@ -241,5 +241,32 @@ class StoreContextTest extends TestCase
             'overwritten',
             $this->injectStoredValues('(the test_property_1 of the testObj)', $goodFn)
         );
+    }
+
+    /**
+     * This tests accessing magic properties on the model.
+     */
+    public function testMagicProperties()
+    {
+        $name = 'magicMock';
+        $mock = $this->getMockBuilder(MagicMethods::class)
+            ->setMethods(['__get', '__isset'])
+            ->getMock();
+
+        $mock->expects($this->once())
+            ->method('__isset')
+            ->with('test_property_1')
+            ->will($this->returnCallback(function ($prop) {
+                return $prop == 'test_property_1';
+            }));
+
+        $mock->expects($this->once())
+            ->method('__get')
+            ->with($this->equalTo('test_property_1'))
+            ->will($this->returnValue('test_value_1'));
+
+        $this->put($mock, $name);
+
+        $this->assertEquals('test_value_1', $this->injectStoredValues("(the test_property_1 of the $name)"));
     }
 }


### PR DESCRIPTION
# Overview

With the new hook for `StoreContext::injectStoredValues` (#70), the method now throws exceptions when attempting to access magic properties (ie. properties set via `Class::__get`). This fix updates the method to handle these magic properties.

# Cause
PHP's `property_exists` only applies to explicit properties, thus will not detect magic properties.

# Changes
```
StoreContext.php
StoreContextTest.php
```
- `injectStoredValues` now updated to handle magic properties using `isset` instead of `property_exists`. This requires that `Class::__isset` is defined, which is standard for dynamic properties.

```
bin/phpunit
```
- Since `phpunit` is now installed by composer, its not a good idea to run it in a separate container with separate source. The script now uses the installed phpunit in the php container