### PR TITLE
Add nth Key Parsing to isStored Method

### DIFF
--- a/src/Behat/FlexibleMink/Context/StoreContext.php
+++ b/src/Behat/FlexibleMink/Context/StoreContext.php
@@ -66,13 +66,30 @@ trait StoreContext
     }
 
     /**
+     * Converts a key of the form "nth thing" into "n" and "thing".
+     *
+     * @param  string $key The key to parse
+     * @return array  For a key "nth thing", returns [thing, n], else [thing, null]
+     */
+    private function parseKey($key)
+    {
+        if (preg_match('/^([1-9][0-9]*)(?:st|nd|rd|th) (.+)$/', $key, $matches)) {
+            $nth = $matches[1];
+            $key = $matches[2];
+        } else {
+            $nth = '';
+        }
+
+        return [$key, $nth];
+    }
+
+    /**
      * {@inheritdoc}
      */
     protected function get($key, $nth = null)
     {
-        if (!$nth && preg_match('/^([1-9][0-9]*)(?:st|nd|rd|th) (.+)$/', $key, $matches)) {
-            $nth = $matches[1];
-            $key = $matches[2];
+        if (!$nth) {
+            list($key, $nth) = $this->parseKey($key);
         }
 
         if (!$this->isStored($key, $nth)) {
@@ -140,6 +157,10 @@ trait StoreContext
      */
     protected function isStored($key, $nth = null)
     {
+        if (!$nth) {
+            list($key, $nth) = $this->parseKey($key);
+        }
+
         return $nth ? isset($this->registry[$key][$nth - 1]) : isset($this->registry[$key]);
     }
 

--- a/tests/Behat/FlexibleMink/Context/StoreContextTest.php
+++ b/tests/Behat/FlexibleMink/Context/StoreContextTest.php
@@ -244,9 +244,9 @@ class StoreContextTest extends TestCase
     }
 
     /**
-     * This tests accessing magic properties on the model.
+     * Tests injectStoredValues using objects with magic properties.
      */
-    public function testMagicProperties()
+    public function testInjectStoredValuesMagicProperties()
     {
         $name = 'magicMock';
         $mock = $this->getMockBuilder(MagicMethods::class)
@@ -268,5 +268,45 @@ class StoreContextTest extends TestCase
         $this->put($mock, $name);
 
         $this->assertEquals('test_value_1', $this->injectStoredValues("(the test_property_1 of the $name)"));
+    }
+
+    /**
+     * Tests the parseKey function.
+     */
+    public function testParseKey()
+    {
+        /***********************
+         * Invalid Format Reflects Back
+         ***********************/
+        $this->assertEquals(['not right', null], $this->parseKey('not right'));
+        $this->assertEquals(['not_right', null], $this->parseKey('not_right'));
+        $this->assertEquals(['1st_not right', null], $this->parseKey('1st_not right'));
+        $this->assertEquals(['not_right_1st', null], $this->parseKey('not_right_1st'));
+        $this->assertEquals(['not right 1st', null], $this->parseKey('not right 1st'));
+
+
+        /***********************
+         * Basic 1st, 2nd, 3rd, etc.
+         ***********************/
+        $this->assertEquals(['University', 1], $this->parseKey('1st University'));
+        $this->assertEquals(['University', 2], $this->parseKey('2nd University'));
+        $this->assertEquals(['University', 3], $this->parseKey('3rd University'));
+        $this->assertEquals(['University', 21], $this->parseKey('21st University'));
+        $this->assertEquals(['University', 500], $this->parseKey('500th University'));
+
+
+        /***********************
+         * Strange Key Names
+         ***********************/
+        $this->assertEquals(['lol$@!@#$', 1], $this->parseKey('1st lol$@!@#$'));
+        $this->assertEquals(['%%%%%', 1], $this->parseKey('1st %%%%%'));
+        $this->assertEquals(['     ', 42], $this->parseKey('42nd      '));
+
+
+        /***********************
+         * No suffix on numbers
+         ***********************/
+        $this->assertEquals(['1 University', null], $this->parseKey('1 University'));
+        $this->assertEquals(['2 University', null], $this->parseKey('2 University'));
     }
 }


### PR DESCRIPTION
# Overview

The `StoreContext::get` method parses the provided `$key` to separate out a potential "n" value and key name. Essentially, you can provide keys in the form of `nth key` and have the method parse the `n` and the `key` out of it.

This behavior is unfortunately not used in the `isStored` method. So if you want to check that a given key is stored before you retrieve it, you have to the key yourself.

# Changes
This PR creates a method for key parsing. Any (local) member needing a key parsed can call the method and have the parse done. This is implemented in `get` and `isStored` so that you can now check the same key that you plan on getting without having to parse stuff yourself.