### PR TITLE
Adding Environment for Docker Timezones

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .idea/*
 /vendor/*
+docker/.env

--- a/bin/composer
+++ b/bin/composer
@@ -1,3 +1,3 @@
 #!/bin/bash +x
 
-docker run --rm -v $(pwd):/data -w /data composer/composer:1.1 $@
+docker run --rm --env-file $(pwd)/docker/.env -v $(pwd):/data -w /data composer/composer:1.1 $@

--- a/bin/composer
+++ b/bin/composer
@@ -1,3 +1,3 @@
 #!/bin/bash +x
 
-docker run --rm --env-file $(pwd)/docker/.env -v $(pwd):/data -w /data composer/composer:1.1 $@
+docker run --rm --env-file "$(pwd)"/docker/.env -v "$(pwd)":/data -w /data composer/composer:1.1 $@

--- a/bin/containers
+++ b/bin/containers
@@ -1,9 +1,19 @@
 #!/bin/bash +x
 
-DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-
+ROOT="$( cd "$( dirname "${BASH_SOURCE[0]}" )/../" && pwd )"
 PROJECT_NAME=flexiblemink
 
+echo "Checking .env file..."
+if [ ! -e $ROOT/docker/.env ]; then
+  echo "No docker/.env file found. Creating from .env.example..."
+  cp $ROOT/docker/.env.example $ROOT/docker/.env
+  echo "NOTE: Please review the docker/.env file and configure any required parameters."
+else
+  echo "docker/.env file exists. Skipping create."
+  echo "NOTE: Please review the docker/.env.example file and ensure all required parameters are present in docker/.env"
+fi
+
+echo "Working on containers..."
 docker-compose -p $PROJECT_NAME \
-    -f "$DIR"/../docker/docker-compose.yml \
+    -f $ROOT/docker/docker-compose.yml \
     "$@"

--- a/bin/containers
+++ b/bin/containers
@@ -4,9 +4,9 @@ ROOT="$( cd "$( dirname "${BASH_SOURCE[0]}" )/../" && pwd )"
 PROJECT_NAME=flexiblemink
 
 echo "Checking .env file..."
-if [ ! -e $ROOT/docker/.env ]; then
+if [ ! -e "$ROOT"/docker/.env ]; then
   echo "No docker/.env file found. Creating from .env.example..."
-  cp $ROOT/docker/.env.example $ROOT/docker/.env
+  cp "$ROOT"/docker/.env.example "$ROOT"/docker/.env
   echo "NOTE: Please review the docker/.env file and configure any required parameters."
 else
   echo "docker/.env file exists. Skipping create."
@@ -15,5 +15,5 @@ fi
 
 echo "Working on containers..."
 docker-compose -p $PROJECT_NAME \
-    -f $ROOT/docker/docker-compose.yml \
+    -f "$ROOT"/docker/docker-compose.yml \
     "$@"

--- a/bin/php
+++ b/bin/php
@@ -1,7 +1,7 @@
 #!/bin/bash +x
 
-docker run --rm -it --env-file $(pwd)/docker/.env \
-    -v $(pwd):/app -w /app \
+docker run --rm -it --env-file "$(pwd)"/docker/.env \
+    -v "$(pwd)":/app -w /app \
 	--link web:dockermachine.local \
 	--net flexiblemink_default \
 	php:7-cli php $@

--- a/bin/php
+++ b/bin/php
@@ -1,6 +1,7 @@
 #!/bin/bash +x
 
-docker run --rm -it -v $(pwd):/app -w /app \
+docker run --rm -it --env-file $(pwd)/docker/.env \
+    -v $(pwd):/app -w /app \
 	--link web:dockermachine.local \
 	--net flexiblemink_default \
 	php:7-cli php $@

--- a/circle.yml
+++ b/circle.yml
@@ -10,6 +10,7 @@ machine:
 
 dependencies:
   override:
+    - cp ./docker/.env.example ./docker/.env
     - sudo pip install docker-compose
     - sudo pip install 'six==1.10.0'
     - docker login -e ${DOCKER_EMAIL} -u ${DOCKER_USERNAME} -p ${DOCKER_PASSWORD}

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -1,0 +1,1 @@
+TZ=America/Chicago

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -1,1 +1,1 @@
-TZ=America/Chicago
+TZ=UTC

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -6,6 +6,7 @@ services:
     volumes:
       - ..:/data
       - ../web:/usr/local/apache2/htdocs:ro
+    env_file: .env
     ports:
       - 80:80
 
@@ -20,6 +21,7 @@ services:
     volumes:
       - /dev/shm:/dev/shm
       - ..:/data
+    env_file: .env
     ports:
       - 4444:4444
       - 5900:5900


### PR DESCRIPTION
Fixes #79.
Port of Medology/stdcheck.com#1702.

**Method**
`docker-compose` and `docker run` do not set timezones on containers meaning everyone has their own timezone.

**Solution:**
New environment file added for docker containers which will set the timezone to America/Chicago by default.