### PR TITLE
Adding Several Prototypes to Mink Interface

### DIFF
--- a/src/Behat/FlexibleMink/PseudoInterface/MinkContextInterface.php
+++ b/src/Behat/FlexibleMink/PseudoInterface/MinkContextInterface.php
@@ -2,11 +2,12 @@
 
 use Behat\Gherkin\Node\TableNode;
 use Behat\Mink\Session;
+use Behat\MinkExtension\Context\MinkContext;
 
 /**
  * Pseudo interface for tracking the methods of the MinkContext.
  *
- * @see \Behat\MinkExtension\Context\MinkContext.
+ * @see MinkContext.
  */
 trait MinkContextInterface
 {

--- a/src/Behat/FlexibleMink/PseudoInterface/MinkContextInterface.php
+++ b/src/Behat/FlexibleMink/PseudoInterface/MinkContextInterface.php
@@ -1,11 +1,12 @@
 <?php namespace Behat\FlexibleMink\PseudoInterface;
 
+use Behat\Gherkin\Node\TableNode;
 use Behat\Mink\Session;
 
 /**
  * Pseudo interface for tracking the methods of the MinkContext.
  *
- * @see Behat\MinkExtension\Context\MinkContext.
+ * @see \Behat\MinkExtension\Context\MinkContext.
  */
 trait MinkContextInterface
 {
@@ -30,6 +31,25 @@ trait MinkContextInterface
      * @param string $value the value to fill
      */
     abstract public function fillField($field, $value);
+
+    /**
+     * Fills in form fields with provided table.
+     *
+     * @param TableNode $fields Pairs of fields and values to fill. Example:
+     *                          [
+     *                          [ username, bruceWayne]
+     *                          [ password, iLoveBats123]
+     *                          ]
+     */
+    abstract public function fillFields(TableNode $fields);
+
+    /**
+     * Selects option in select field with specified id|name|label|value.
+     *
+     * @param string $select The select field
+     * @param string $option The option to select in the field
+     */
+    abstract public function selectOption($select, $option);
 
     /**
      * Returns the Mink session.

--- a/src/Behat/FlexibleMink/PseudoInterface/MinkContextInterface.php
+++ b/src/Behat/FlexibleMink/PseudoInterface/MinkContextInterface.php
@@ -36,10 +36,8 @@ trait MinkContextInterface
      * Fills in form fields with provided table.
      *
      * @param TableNode $fields Pairs of fields and values to fill. Example:
-     *                          [
-     *                          [ username, bruceWayne]
-     *                          [ password, iLoveBats123]
-     *                          ]
+     *                          | username | bruceWayne |
+     *                          | password | iLoveBats123 |
      */
     abstract public function fillFields(TableNode $fields);
 


### PR DESCRIPTION
The following prototypes are added to the Mink psuedo-interface.

- `fillFields()`
- `selectOption()`

These are to resolve Scrutinizer issues showing up in projects which use Flex Mink.