### PR TITLE
Allow custom logic for property exists.

### DIFF
--- a/src/Behat/FlexibleMink/Context/StoreContext.php
+++ b/src/Behat/FlexibleMink/Context/StoreContext.php
@@ -116,10 +116,22 @@ trait StoreContext
     /**
      * {@inheritdoc}
      */
-    protected function injectStoredValues($string, callable $onGetFn = null)
+    protected function injectStoredValues($string, callable $onGetFn = null, callable $hasValue = null)
     {
         if ($onGetFn && (new ReflectionFunction($onGetFn))->getNumberOfParameters() != 1) {
             throw new Exception('Method $onGetFn must take one argument!');
+        }
+
+        if ($hasValue) {
+            if ((new ReflectionFunction($hasValue))->getNumberOfParameters() != 2) {
+                throw new Exception('Lambda $hasValue must take two arguments!');
+            }
+        } else {
+            $hasValue = function($thing, $property) {
+                return !
+                    (is_object($thing) && !isset($thing->$property)) ||
+                    (is_array($thing) && !isset($thing[$property]));
+            };
         }
 
         preg_match_all('/\(the ([^\)]+) of the ([^\)]+)\)/', $string, $matches);
@@ -139,10 +151,12 @@ trait StoreContext
                 throw new Exception('The $onGetFn method must return an object or an array!');
             }
 
-            if (
-                (is_object($thing) && !isset($thing->$thingProperty)) ||
-                (is_array($thing) && !isset($thing[$thingProperty]))
-            ) {
+            $hasValueResult = $hasValue($thing, $thingProperty);
+            if (!is_bool($hasValueResult)) {
+                throw new Exception('$hasValue lambda must return a boolean!');
+            }
+
+            if (!$hasValueResult) {
                 throw new Exception("$thingName does not have a $thingProperty property");
             }
 

--- a/src/Behat/FlexibleMink/Context/StoreContext.php
+++ b/src/Behat/FlexibleMink/Context/StoreContext.php
@@ -127,9 +127,8 @@ trait StoreContext
                 throw new Exception('Lambda $hasValue must take two arguments!');
             }
         } else {
-            $hasValue = function($thing, $property) {
-                return !
-                    (is_object($thing) && !isset($thing->$property)) ||
+            $hasValue = function ($thing, $property) {
+                return !(is_object($thing) && !isset($thing->$property)) ||
                     (is_array($thing) && !isset($thing[$property]));
             };
         }

--- a/src/Behat/FlexibleMink/PseudoInterface/StoreContextInterface.php
+++ b/src/Behat/FlexibleMink/PseudoInterface/StoreContextInterface.php
@@ -53,15 +53,22 @@ trait StoreContextInterface
     /**
      * Parses the string for references to stored items and replaces them with the value from the store.
      *
-     * @param  string    $string  String to parse.
-     * @param  callable  $onGetFn Used to modify a resource after it is retrieved from store and before properties of
-     *                            it are accessed. Takes one argument, the resource retrieved and returns the resource
-     *                            after modifying it.
-     *                            $thing = $onGetFn($thing);
+     * @param  string    $string   String to parse.
+     * @param  callable  $onGetFn  Used to modify a resource after it is retrieved from store and before properties of
+     *                             it are accessed. Takes one argument, the resource retrieved and returns the resource
+     *                             after modifying it.
+     *                             $thing = $onGetFn($thing);
+     * @param  callable  $hasValue Used to determine if the thing in the store has the required value. Will default
+     *                             to using isset on objects and arrays if not present. The callable should take two
+     *                             arguments:
+     *
+     *                                  $thing    - mixed  - The thing from the store.
+     *                                  $property - string - The name of the property (or key, etc) to check for.
+     *
      * @throws Exception If the string references something that does not exist in the store.
      * @return string    The parsed string.
      */
-    abstract protected function injectStoredValues($string, callable $onGetFn = null);
+    abstract protected function injectStoredValues($string, callable $onGetFn = null, callable $hasValue = null);
 
     /**
      * Checks that the specified thing exists in the registry.

--- a/src/Behat/FlexibleMink/PseudoInterface/StoreContextInterface.php
+++ b/src/Behat/FlexibleMink/PseudoInterface/StoreContextInterface.php
@@ -53,17 +53,17 @@ trait StoreContextInterface
     /**
      * Parses the string for references to stored items and replaces them with the value from the store.
      *
-     * @param  string    $string   String to parse.
-     * @param  callable  $onGetFn  Used to modify a resource after it is retrieved from store and before properties of
-     *                             it are accessed. Takes one argument, the resource retrieved and returns the resource
-     *                             after modifying it.
-     *                             $thing = $onGetFn($thing);
-     * @param  callable  $hasValue Used to determine if the thing in the store has the required value. Will default
-     *                             to using isset on objects and arrays if not present. The callable should take two
-     *                             arguments:
+     * @param string   $string   String to parse.
+     * @param callable $onGetFn  Used to modify a resource after it is retrieved from store and before properties of
+     *                           it are accessed. Takes one argument, the resource retrieved and returns the resource
+     *                           after modifying it.
+     *                           $thing = $onGetFn($thing);
+     * @param callable $hasValue Used to determine if the thing in the store has the required value. Will default
+     *                           to using isset on objects and arrays if not present. The callable should take two
+     *                           arguments:
      *
-     *                                  $thing    - mixed  - The thing from the store.
-     *                                  $property - string - The name of the property (or key, etc) to check for.
+     *                             $thing    - mixed  - The thing from the store.
+     *                             $property - string - The name of the property (or key, etc) to check for.
      *
      * @throws Exception If the string references something that does not exist in the store.
      * @return string    The parsed string.

--- a/tests/Behat/FlexibleMink/Context/StoreContextTest.php
+++ b/tests/Behat/FlexibleMink/Context/StoreContextTest.php
@@ -241,6 +241,110 @@ class StoreContextTest extends TestCase
             'overwritten',
             $this->injectStoredValues('(the test_property_1 of the testObj)', $goodFn)
         );
+
+        /******************************
+         * Validate $hasValue argument
+         *****************************/
+
+        // test null values
+        $this->assertEmpty($this->injectStoredValues('', null, null));
+
+        // test invalid values
+        try {
+            $this->injectStoredValues('', null, '');
+            $this->expectException(TypeError::class);
+        } catch (TypeError $e) {
+            $this->assertNotEquals(-1, strpos($e->getMessage(), 'injectStoredValues() must be callable'));
+        }
+
+        try {
+            $this->injectStoredValues('', null, 0);
+            $this->expectException(TypeError::class);
+        } catch (TypeError $e) {
+            $this->assertNotEquals(-1, strpos($e->getMessage(), 'injectStoredValues() must be callable'));
+        }
+
+        try {
+            $this->injectStoredValues('', null, $testObj);
+            $this->expectException(TypeError::class);
+        } catch (TypeError $e) {
+            $this->assertNotEquals(-1, strpos($e->getMessage(), 'injectStoredValues() must be callable'));
+        }
+
+        // test function with bad arguments
+        $badFn = function () {
+        };
+        try {
+            $this->injectStoredValues('(the test_property_1 of the testObj)', null, $badFn);
+            $this->expectException(Exception::class);
+        } catch (Exception $e) {
+            $this->assertInstanceOf(Exception::class, $e);
+            $this->assertEquals('Lambda $hasValue must take two arguments!', $e->getMessage());
+        }
+
+        $badFn = function ($a) {
+        };
+        try {
+            $this->injectStoredValues('(the test_property_1 of the testObj)', null, $badFn);
+            $this->expectException(Exception::class);
+        } catch (Exception $e) {
+            $this->assertInstanceOf(Exception::class, $e);
+            $this->assertEquals('Lambda $hasValue must take two arguments!', $e->getMessage());
+        }
+
+        $badFn = function ($a, $b, $c) {
+        };
+        try {
+            $this->injectStoredValues('(the test_property_1 of the testObj)', null, $badFn);
+            $this->expectException(Exception::class);
+        } catch (Exception $e) {
+            $this->assertInstanceOf(Exception::class, $e);
+            $this->assertEquals('Lambda $hasValue must take two arguments!', $e->getMessage());
+        }
+
+        // test function with no return
+        $badFn = function ($thing, $property) {
+        };
+        try {
+            $this->injectStoredValues('(the test_property_1 of the testObj)', null, $badFn);
+            $this->expectException(Exception::class);
+        } catch (Exception $e) {
+            $this->assertInstanceOf(Exception::class, $e);
+            $this->assertEquals('$hasValue lambda must return a boolean!', $e->getMessage());
+        }
+
+        // test function with bad return
+        $badFn = function ($thing, $property) {
+            return 'bad return';
+        };
+        try {
+            $this->injectStoredValues('(the test_property_1 of the testObj)', null, $badFn);
+            $this->expectException(Exception::class);
+        } catch (Exception $e) {
+            $this->assertInstanceOf(Exception::class, $e);
+            $this->assertEquals('$hasValue lambda must return a boolean!', $e->getMessage());
+        }
+
+        $badFn = function ($thing, $property) {
+            return function () {
+            };
+        };
+        try {
+            $this->injectStoredValues('(the test_property_1 of the testObj)', null, $badFn);
+            $this->expectException(Exception::class);
+        } catch (Exception $e) {
+            $this->assertInstanceOf(Exception::class, $e);
+            $this->assertEquals('$hasValue lambda must return a boolean!', $e->getMessage());
+        }
+
+        // test with property
+        $goodFn = function ($thing, $property) {
+            return isset($thing->$property);
+        };
+        $this->assertEquals(
+            'overwritten',
+            $this->injectStoredValues('(the test_property_1 of the testObj)', null, $goodFn)
+        );
     }
 
     /**

--- a/tests/Behat/FlexibleMink/Context/StoreContextTest.php
+++ b/tests/Behat/FlexibleMink/Context/StoreContextTest.php
@@ -260,7 +260,15 @@ class StoreContextTest extends TestCase
         }
 
         // Lambda without two args throws appropriate error
-        foreach ([function () {}, function ($a) {}, function ($a, $b, $c) {}] as $wrongArgCount) {
+        $wrongArgCount = [
+            function () {
+            },
+            function ($a) {
+            },
+            function ($a, $b, $c) {
+            },
+        ];
+        foreach ($wrongArgCount as $wrongArgCount) {
             try {
                 $this->injectStoredValues('(the test_property_1 of the testObj)', null, $wrongArgCount);
                 $this->expectException(Exception::class);
@@ -272,9 +280,15 @@ class StoreContextTest extends TestCase
 
         // Lambda with wrong return type throws appropriate error
         $wrongReturnTypes = [
-            function ($a, $b) {}, // null
-            function ($a, $b) { return ''; }, // string
-            function ($a, $b) { return function () {}; }, // callable
+            function ($a, $b) {
+            },
+            function ($a, $b) {
+                return '';
+            },
+            function ($a, $b) {
+                return function () {
+                };
+            },
         ];
         foreach ($wrongReturnTypes as $wrongReturnType) {
             try {
@@ -291,7 +305,9 @@ class StoreContextTest extends TestCase
             $this->injectStoredValues(
                 '(the test_property_1 of the testObj)',
                 null,
-                function ($a, $b) { return false; }
+                function ($a, $b) {
+                    return false;
+                }
             );
             $this->expectException(Exception::class);
         } catch (Exception $e) {


### PR DESCRIPTION
Problem:
I need to use injectStoredValues to inject the deleted_at from an Eloquent model, whatever that value might be. However, deleted_at will be set to null if the model has not been deleted. This is a perfectly valid value, but because injectStoredValues uses isset to determine if the item from the store has a property, it throws an Exception claiming that the model does not have a deleted_at property, when it clearly does (it's just null).

Fix:
After trying a myriad of different options, the only solution that was close to satisfactory was to add the option to pass a lambda into the injectStoredValues function that allows you to change the behavior of how a thing it determined to have a value or not. This allows an Eloquent user to pass in a lambda that supports Eloquent, while avoiding tightly coupling the FlexibleMink framework to Eloquent itself.

For example, I could pass in the following:

```php
   function eloquentHasProperty($thing, $property) {
        if ($thing instanceof Model) {
            return array_key_exists($property, $thing->getAttributes()) || $thing->hasGetMutator($property);
        } else {
            return
                (is_object($thing) && !isset($thing->$property)) ||
                (is_array($thing) && !isset($thing[$property]));
        }
    }
```

Which would allow injectStoredValues to properly detect properties on an Eloquent model, even if they were null, or generated via a mutator.