### PR TITLE
Change waitFor to Sleep for 1/10 Second

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,8 +1,13 @@
 {
   "name": "medology/flexible-mink",
-  "type": "behat-extension",
-  "description": "Mink extension with patient assertions and object storage",
+  "type": "library",
+  "description": "Mink Extensions for Commonly Used Assertions and Object Storage",
+  "keywords": ["mink", "behat", "testing"],
   "license": "MIT",
+  "support": {
+    "issues": "https://github.com/Medology/FlexibleMink/issues",
+    "source": "https://github.com/Medology/FlexibleMink"
+  },
   "require": {
     "php": ">=5.4.41",
     "behat/behat": "^3.0",

--- a/src/Behat/FlexibleMink/Context/SpinnerContext.php
+++ b/src/Behat/FlexibleMink/Context/SpinnerContext.php
@@ -26,8 +26,8 @@ trait SpinnerContext
                 $lastException = $e;
             }
 
-            # sleep for 10^8 nanoseconds (0.1 second)
-            time_nanosleep(0, pow(10,8));
+            // sleep for 10^8 nanoseconds (0.1 second)
+            time_nanosleep(0, pow(10, 8));
         }
 
         throw $lastException;

--- a/src/Behat/FlexibleMink/Context/SpinnerContext.php
+++ b/src/Behat/FlexibleMink/Context/SpinnerContext.php
@@ -26,7 +26,8 @@ trait SpinnerContext
                 $lastException = $e;
             }
 
-            sleep(1);
+            # sleep for 10^8 nanoseconds (0.1 second)
+            time_nanosleep(0, pow(10,8));
         }
 
         throw $lastException;


### PR DESCRIPTION
### Overview
Simple PR, changes the waitFor function to sleep for a 1/10th of a second instead of a full second (since that's actually quite long).

We're doing this to catch any kind of transitions which happen in a window of less than 1 second (such as hide/show status messages).

### Miscellaneous
I'm also updating the `composer.json` with meta information about the project.