### PR TITLE
adding waitForPageNotContainsText method

### DIFF
--- a/src/Behat/FlexibleMink/Context/FlexibleContext.php
+++ b/src/Behat/FlexibleMink/Context/FlexibleContext.php
@@ -100,15 +100,21 @@ class FlexibleContext extends MinkContext
     /**
      * {@inheritdoc}
      *
-     * @When I wait until I do not see :text
+     * @When I wait until I see and then do not see :text
      */
     public function waitForPageNotContainsText($text)
     {
+        $this->waitFor(function () use ($text) {
+            parent::assertPageContainsText($text);
+        }, 15);
+
         try {
-            $this->assertPageNotContainsText($text);
+            $this->waitFor(function () use ($text) {
+                parent::assertPageContainsText($text);
+            }, 15);
         } catch (ExpectationException $e) {
             throw new ResponseTextException(
-                "Wait For timed out waiting for '$text' to no longer appear.", $this->getSession()
+                "Timed out waiting for '$text' to no longer appear.", $this->getSession()
             );
         }
     }

--- a/src/Behat/FlexibleMink/Context/FlexibleContext.php
+++ b/src/Behat/FlexibleMink/Context/FlexibleContext.php
@@ -6,6 +6,7 @@ use Behat\FlexibleMink\PseudoInterface\FlexibleContextInterface;
 use Behat\Gherkin\Node\TableNode;
 use Behat\Mink\Element\NodeElement;
 use Behat\Mink\Exception\ExpectationException;
+use Behat\Mink\Exception\ResponseTextException;
 use Behat\Mink\Exception\UnsupportedDriverActionException;
 use Behat\MinkExtension\Context\MinkContext;
 use InvalidArgumentException;
@@ -94,6 +95,22 @@ class FlexibleContext extends MinkContext
         $this->waitFor(function () use ($text) {
             parent::assertPageNotContainsText($text);
         });
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @When I wait until I do not see :text
+     */
+    public function waitForPageNotContainsText($text)
+    {
+        try {
+            $this->assertPageNotContainsText($text);
+        } catch (ExpectationException $e) {
+            throw new ResponseTextException(
+                "Wait For timed out waiting for '$text' to no longer appear.", $this->getSession()
+            );
+        }
     }
 
     /**

--- a/src/Behat/FlexibleMink/PseudoInterface/FlexibleContextInterface.php
+++ b/src/Behat/FlexibleMink/PseudoInterface/FlexibleContextInterface.php
@@ -70,13 +70,13 @@ trait FlexibleContextInterface
     abstract public function assertPageNotContainsText($text);
 
     /**
-     * Waits for the default `waitFor` time for text to not appear on the page.
-     * This does exactly the same thing as `assertPageNotContainsText` with the only difference being the exception
-     * message considering that this is a `@When` step.
+     * This method will wait to see the text specified for 15 seconds, and then wait another 15 seconds for the text
+     * to no longer appear on the page.
      *
      * @see assertPageNotContainsText()
      * @param  string                $text The text to wait on to not show up on the page anymore.
-     * @throws ResponseTextException If the text is still found after the 30 seconds.
+     * @throws ResponseTextException If the text is not found initially or if the text was still visible after seeing
+     *                                    it and waiting for 15 seconds.
      */
     abstract public function waitForPageNotContainsText($text);
 

--- a/src/Behat/FlexibleMink/PseudoInterface/FlexibleContextInterface.php
+++ b/src/Behat/FlexibleMink/PseudoInterface/FlexibleContextInterface.php
@@ -70,6 +70,17 @@ trait FlexibleContextInterface
     abstract public function assertPageNotContainsText($text);
 
     /**
+     * Waits for the default `waitFor` time for text to not appear on the page.
+     * This does exactly the same thing as `assertPageNotContainsText` with the only difference being the exception
+     * message considering that this is a `@When` step.
+     *
+     * @see assertPageNotContainsText()
+     * @param  string                $text The text to wait on to not show up on the page anymore.
+     * @throws ResponseTextException If the text is still found after the 30 seconds.
+     */
+    abstract public function waitForPageNotContainsText($text);
+
+    /**
      * This method overrides the MinkContext::assertElementContainsText() default behavior for
      * assertElementContainsText to ensure that it waits for the item to be available with a max time limit.
      *


### PR DESCRIPTION
There is currently already a method which can already test for this. The only difference is the exception message thrown.  Since the step definition is a when, this exception message seems more clear.