### PR TITLE
Context for assert field exists and patiences for button/options

### DIFF
--- a/src/Behat/FlexibleMink/Context/FlexibleContext.php
+++ b/src/Behat/FlexibleMink/Context/FlexibleContext.php
@@ -4,8 +4,8 @@ namespace Behat\FlexibleMink\Context;
 
 use Behat\FlexibleMink\PseudoInterface\FlexibleContextInterface;
 use Behat\Gherkin\Node\TableNode;
-use Behat\Mink\Element\DocumentElement;
 use Behat\Mink\Element\NodeElement;
+use Behat\Mink\Element\TraversableElement;
 use Behat\Mink\Exception\ExpectationException;
 use Behat\Mink\Exception\ResponseTextException;
 use Behat\Mink\Exception\UnsupportedDriverActionException;
@@ -269,7 +269,7 @@ class FlexibleContext extends MinkContext
     /**
      * {@inheritdoc}
      */
-    public function assertFieldExists($fieldName, DocumentElement $context = null)
+    public function assertFieldExists($fieldName, TraversableElement $context = null)
     {
         if (!$context) {
             $context = $this->getSession()->getPage();

--- a/src/Behat/FlexibleMink/Context/FlexibleContext.php
+++ b/src/Behat/FlexibleMink/Context/FlexibleContext.php
@@ -144,7 +144,11 @@ class FlexibleContext extends MinkContext
      */
     public function checkOption($locator)
     {
-        $this->assertVisibleOption($locator)->check();
+        $element = $this->waitFor(function() use($locator) {
+           return $this->assertVisibleOption($locator);
+        });
+
+        $element->check();
     }
 
     /**

--- a/src/Behat/FlexibleMink/Context/FlexibleContext.php
+++ b/src/Behat/FlexibleMink/Context/FlexibleContext.php
@@ -145,8 +145,8 @@ class FlexibleContext extends MinkContext
      */
     public function checkOption($locator)
     {
-        $element = $this->waitFor(function() use($locator) {
-           return $this->assertVisibleOption($locator);
+        $element = $this->waitFor(function () use ($locator) {
+            return $this->assertVisibleOption($locator);
         });
 
         $element->check();

--- a/src/Behat/FlexibleMink/Context/FlexibleContext.php
+++ b/src/Behat/FlexibleMink/Context/FlexibleContext.php
@@ -4,6 +4,7 @@ namespace Behat\FlexibleMink\Context;
 
 use Behat\FlexibleMink\PseudoInterface\FlexibleContextInterface;
 use Behat\Gherkin\Node\TableNode;
+use Behat\Mink\Element\DocumentElement;
 use Behat\Mink\Element\NodeElement;
 use Behat\Mink\Exception\ExpectationException;
 use Behat\Mink\Exception\ResponseTextException;
@@ -268,18 +269,22 @@ class FlexibleContext extends MinkContext
     /**
      * {@inheritdoc}
      */
-    public function assertFieldExists($fieldName)
+    public function assertFieldExists($fieldName, DocumentElement $context = null)
     {
+        if (!$context) {
+            $context = $this->getSession()->getPage();
+        }
+
         /** @var NodeElement[] $fields */
-        $fields = $this->getSession()->getPage()->findAll('named', ['field', $fieldName]);
+        $fields = $context->findAll('named', ['field', $fieldName]);
         if (count($fields) == 0) {
             // If the field was not found with the usual way above, attempt to find with label name as last resort
-            $label = $this->getSession()->getPage()->find('xpath', "//label[contains(text(), '$fieldName')]");
+            $label = $context->find('xpath', "//label[contains(text(), '$fieldName')]");
             if (!$label) {
                 throw new ExpectationException("No input label '$fieldName' found", $this->getSession());
             }
             $name = $label->getAttribute('for');
-            $fields = [$this->getSession()->getPage()->findField($name)];
+            $fields = [$context->findField($name)];
         }
         if (count($fields) > 0) {
             foreach ($fields as $field) {

--- a/src/Behat/FlexibleMink/Context/FlexibleContext.php
+++ b/src/Behat/FlexibleMink/Context/FlexibleContext.php
@@ -500,7 +500,11 @@ class FlexibleContext extends MinkContext
      */
     public function pressButton($locator)
     {
-        $this->assertVisibleButton($locator)->press();
+        $element = $this->waitFor(function () use ($locator) {
+            return $this->assertVisibleButton($locator);
+        });
+
+        $element->press();
     }
 
     /**

--- a/src/Behat/FlexibleMink/PseudoInterface/FlexibleContextInterface.php
+++ b/src/Behat/FlexibleMink/PseudoInterface/FlexibleContextInterface.php
@@ -249,7 +249,7 @@ trait FlexibleContextInterface
      * Presses the visible button with specified id|name|title|alt|value.
      *
      * This method overrides the MinkContext::pressButton() default behavior for pressButton to ensure that only visible
-     * buttons are pressed.
+     * buttons are pressed and that it waits for the button to be available with a max time limit.
      *
      * @see MinkContext::pressButton
      * @param  string               $button button id, inner text, value or alt

--- a/src/Behat/FlexibleMink/PseudoInterface/FlexibleContextInterface.php
+++ b/src/Behat/FlexibleMink/PseudoInterface/FlexibleContextInterface.php
@@ -3,6 +3,7 @@
 namespace Behat\FlexibleMink\PseudoInterface;
 
 use Behat\Gherkin\Node\TableNode;
+use Behat\Mink\Element\DocumentElement;
 use Behat\Mink\Element\NodeElement;
 use Behat\Mink\Exception\DriverException;
 use Behat\Mink\Exception\ElementNotFoundException;
@@ -158,11 +159,12 @@ trait FlexibleContextInterface
     /**
      * Checks that the page contains a visible input field and then returns it.
      *
-     * @param $fieldName
+     * @param string               $fieldName The input name.
+     * @param DocumentElement|null $context   The context to search in, if not provided defaults to page.
      * @throws ExpectationException If a visible input field is not found.
      * @return NodeElement          The found input field.
      */
-    abstract public function assertFieldExists($fieldName);
+    abstract public function assertFieldExists($fieldName, DocumentElement $context = null);
 
     /**
      * Checks that the page not contain a visible input field.

--- a/src/Behat/FlexibleMink/PseudoInterface/FlexibleContextInterface.php
+++ b/src/Behat/FlexibleMink/PseudoInterface/FlexibleContextInterface.php
@@ -3,8 +3,8 @@
 namespace Behat\FlexibleMink\PseudoInterface;
 
 use Behat\Gherkin\Node\TableNode;
-use Behat\Mink\Element\DocumentElement;
 use Behat\Mink\Element\NodeElement;
+use Behat\Mink\Element\TraversableElement;
 use Behat\Mink\Exception\DriverException;
 use Behat\Mink\Exception\ElementNotFoundException;
 use Behat\Mink\Exception\ExpectationException;
@@ -159,12 +159,12 @@ trait FlexibleContextInterface
     /**
      * Checks that the page contains a visible input field and then returns it.
      *
-     * @param  string               $fieldName The input name.
-     * @param  DocumentElement|null $context   The context to search in, if not provided defaults to page.
-     * @throws ExpectationException If a visible input field is not found.
-     * @return NodeElement          The found input field.
+     * @param  string                  $fieldName The input name.
+     * @param  TraversableElement|null $context   The context to search in, if not provided defaults to page.
+     * @throws ExpectationException    If a visible input field is not found.
+     * @return NodeElement             The found input field.
      */
-    abstract public function assertFieldExists($fieldName, DocumentElement $context = null);
+    abstract public function assertFieldExists($fieldName, TraversableElement $context = null);
 
     /**
      * Checks that the page not contain a visible input field.

--- a/src/Behat/FlexibleMink/PseudoInterface/FlexibleContextInterface.php
+++ b/src/Behat/FlexibleMink/PseudoInterface/FlexibleContextInterface.php
@@ -105,7 +105,7 @@ trait FlexibleContextInterface
      * Clicks a visible checkbox with specified id|title|alt|text.
      *
      * This method overrides the MinkContext::checkOption() default behavior for checkOption to ensure that only visible
-     * options are checked.
+     * options are checked and that it waits for the option to be available with a max time limit.
      * @see MinkContext::checkOption
      * @param string $locator The id|title|alt|text of the option to be clicked.
      */

--- a/src/Behat/FlexibleMink/PseudoInterface/FlexibleContextInterface.php
+++ b/src/Behat/FlexibleMink/PseudoInterface/FlexibleContextInterface.php
@@ -159,8 +159,8 @@ trait FlexibleContextInterface
     /**
      * Checks that the page contains a visible input field and then returns it.
      *
-     * @param string               $fieldName The input name.
-     * @param DocumentElement|null $context   The context to search in, if not provided defaults to page.
+     * @param  string               $fieldName The input name.
+     * @param  DocumentElement|null $context   The context to search in, if not provided defaults to page.
      * @throws ExpectationException If a visible input field is not found.
      * @return NodeElement          The found input field.
      */


### PR DESCRIPTION
3 Changes:

- Added waitFor to press button function
- Added waitFor to check option function
- Added context to assert field exists, by default the entire page is the context if not defined.