### PR TITLE
Assertion: Table should have following values

### DIFF
--- a/features/TableContext.feature
+++ b/features/TableContext.feature
@@ -30,3 +30,24 @@ Feature: Table Context
         | Country           | India       |
         | Female Population | 592,067,546 |
 
+  Scenario: Throw exception if the named table does not exist
+    When I assert that I should see table "pupil-table"
+    Then the assertion should throw an ExpectationException
+     And the assertion should fail with the message "Could not find table with name 'pupil-table'."
+
+  Scenario: Throw exception if the named table is not visible
+    When I assert that I should see table "voter-turnout-table"
+    Then the assertion should throw an RuntimeException
+     And the assertion should fail with the message "Found table 'voter-turnout-table', but it is not visible!"
+
+  Scenario: Throw exception if the named table does not have a header
+     When I assert that the table "headless-table" should have "Country" at (1,1) in the body
+     Then the assertion should throw an ElementNotFoundException
+      And the assertion should fail with the message "Tr not found."
+
+  Scenario: Throw exception if the named table does not have the expected values
+    When I assert that the table "population-table" should have the following values:
+      | Country           | Pluto       |
+      | Female Population | 412,064,436 |
+    Then the assertion should throw an ExpectationException
+     And the assertion should fail with the message "A row matching the supplied values could not be found."

--- a/features/TableContext.feature
+++ b/features/TableContext.feature
@@ -3,23 +3,24 @@ Feature: Table Context
   As a developer
   I should have extendable table assertions
 
+  Background:
+    Given I am on "/table.html"
+
   Scenario: Developer can Test if a Table Exist
-    When I am on "/table.html"
     Then I should see table "population-table"
 
   Scenario: Developer Can Test For Number of Table Rows and Columns
-     Given I am on "/table.html"
-      Then the table "population-table" should have 2 columns
+      Then the table "population-table" should have 4 columns
       Then the table "population-table" should have 3 rows
 
   Scenario: Developer Can Test for Table Column Titles
-    Given I am on "/table.html"
      Then the table "population-table" should have the following column titles:
-        | Country    |
-        | Population |
+       | Country           |
+       | Female Population |
+       | Male Population   |
+       | Population        |
 
   Scenario: Developer Can Test for Cell Values in the Table
-    Given I am on "/table.html"
      Then the table "population-table" should have "Country" at (1,1) in the header
-      And the table "population-table" should have "1,377,672,822" at (1,2) in the body
-      And the table "population-table" should have "2,994,159,700" at (1,2) in the footer
+      And the table "population-table" should have "1,341,335,152" at (1,4) in the body
+      And the table "population-table" should have "2,876,333,427" at (1,4) in the footer

--- a/features/TableContext.feature
+++ b/features/TableContext.feature
@@ -24,3 +24,9 @@ Feature: Table Context
      Then the table "population-table" should have "Country" at (1,1) in the header
       And the table "population-table" should have "1,341,335,152" at (1,4) in the body
       And the table "population-table" should have "2,876,333,427" at (1,4) in the footer
+
+  Scenario: Developer Can Test for Row Values in the Table
+      Then the table "population-table" should have the following values:
+        | Country           | India       |
+        | Female Population | 592,067,546 |
+

--- a/src/Behat/FlexibleMink/Context/TableContext.php
+++ b/src/Behat/FlexibleMink/Context/TableContext.php
@@ -441,4 +441,33 @@ trait TableContext
             );
         });
     }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @Then  the table :name should have the following values:
+     */
+    public function assertTableShouldHaveTheFollowingValues($name, TableNode $tableNode)
+    {
+        $actualTable = $this->getTableFromName($name);
+        $expectedRow = $tableNode->getRowsHash();
+        $colHeaders = $actualTable['colHeaders'];
+
+        array_walk($actualTable['body'], function (&$row) use ($colHeaders) {
+            $row = array_combine($colHeaders, $row);
+        });
+
+        $expectedColumnsCount = count($expectedRow);
+
+        foreach ($actualTable['body'] as $row) {
+            if (count(array_intersect_assoc($expectedRow, $row)) == $expectedColumnsCount) {
+                return;
+            }
+        }
+
+        throw new ExpectationException(
+            'A row matching the supplied values could not be found.',
+            $this->getSession()
+        );
+    }
 }

--- a/src/Behat/FlexibleMink/PseudoInterface/TableContextInterface.php
+++ b/src/Behat/FlexibleMink/PseudoInterface/TableContextInterface.php
@@ -83,4 +83,13 @@ trait TableContextInterface
      * @return mixed
      */
     abstract public function assertTableWithStructureExists(TableNode $tableNode);
+
+    /**
+     * Asserts that the table contains a row with the provided values.
+     *
+     * @param  string               $name      The name of the table
+     * @param  TableNode            $tableNode The list of values to search.
+     * @throws ExpectationException If the values are not found in the table.
+     */
+    abstract public function assertTableShouldHaveTheFollowingValues($name, TableNode $tableNode);
 }

--- a/web/table.html
+++ b/web/table.html
@@ -45,6 +45,103 @@
       </tr>
     </tfoot>
   </table>
+
+  <table id="headless-table">
+    <tbody>
+      <tr>
+        <td>1</td>
+        <td>2</td>
+        <td>3</td>
+      </tr>
+    </tbody>
+  </table>
+
+  <table style="display:none;" id="voter-turnout-table">
+    <caption>(in thousands)</caption>
+    <thead>
+    <tr>
+      <th>Election</th>
+      <th>Voting Age Population (VAP)</th>
+      <th>Turnout</th>
+      <th>% Turnout of VAP</th>
+    </tr>
+    </thead>
+  <tbody>
+  <tr>
+    <td>1968</td>
+    <td>120,285</td>
+    <td>73,027</td>
+    <td>60.7%</td>
+  </tr>
+  <tr>
+    <td>1972</td>
+    <td>140,777</td>
+    <td>77,625</td>
+    <td>55.1%</td>
+  </tr>
+  <tr>
+    <td>1976</td>
+    <td>152,308</td>
+    <td>81,603</td>
+    <td>53.6%</td>
+  </tr>
+  <tr>
+    <td>1980</td>
+    <td>163,945</td>
+    <td>86,497</td>
+    <td>52.8%</td>
+  </tr>
+  <tr>
+    <td>1984</td>
+    <td>173,995</td>
+    <td>92,655</td>
+    <td>53.3%</td>
+  </tr>
+  <tr>
+    <td>1988</td>
+    <td>181,956</td>
+    <td>91,587</td>
+    <td>50.3%</td>
+  </tr>
+  <tr>
+    <td>1992</td>
+    <td>189,493</td>
+    <td>104,600</td>
+    <td>55.2%</td>
+  </tr>
+  <tr>
+    <td>1996</td>
+    <td>196,789</td>
+    <td>96,390</td>
+    <td>49.0%</td>
+  </tr>
+  <tr>
+    <td>2000</td>
+    <td>209,787</td>
+    <td>105,594</td>
+    <td>50.3%</td>
+  </tr>
+  <tr>
+    <td>2004</td>
+    <td>219,553</td>
+    <td>122,349</td>
+    <td>55.7%</td>
+  </tr>
+  <tr>
+    <td>2008</td>
+    <td>229,945</td>
+    <td>131,407</td>
+    <td>57.1%</td>
+  </tr>
+  <tr>
+    <td>2012</td>
+    <td>235,248</td>
+    <td>129,235</td>
+    <td>54.9%</td>
+  </tr>
+  </tbody>
+    <tfoot></tfoot>
+  </table>
 </body>
 
 </html>

--- a/web/table.html
+++ b/web/table.html
@@ -7,30 +7,41 @@
 
 <body>
   <table id="population-table">
+    <caption>2010</caption>
     <thead>
       <tr>
         <th>Country</th>
+        <th>Female Population</th>
+        <th>Male Population</th>
         <th colspan="1">Population</th>
       </tr>
     </thead>
     <tbody>
       <tr>
         <th>China</th>
-        <td>1,377,672,822</td>
+        <td>644,994,400</td>
+        <td>696,340,752</td>
+        <td>1,341,335,152</td>
       </tr>
       <tr>
         <th>India</th>
-        <td>1,292,412,878</td>
+        <td>592,067,546</td>
+        <td>632,546,781</td>
+        <td>1,224,614,327</td>
       </tr>
       <tr>
-        <th>United States</th>
-        <td>324,074,000</td>
+        <th>United States of America</th>
+        <td>157,244,385</td>
+        <td>153,139,563</td>
+        <td>310,383,948</td>
       </tr>
     </tbody>
     <tfoot>
       <tr>
         <th>Total</th>
-        <th>2,994,159,700</th>
+        <th>1,394,306,331</th>
+        <th>1,482,027,096</th>
+        <th>2,876,333,427</th>
       </tr>
     </tfoot>
   </table>


### PR DESCRIPTION
Using the header columns to assert that a table contains a row with the provided values, converts the following madness:

```Gherkin
Then the table "product-list" should have "Jeans" at (1,1) in the body
 And the table "product-list" should have "Boot Cut" at (1,2) in the body
 And the table "product-list" should have "32x34" at (1,3) in the body
 And the table "product-list" should have "13.00" at (1,4) in the body
 And the table "product-list" should have "3.00" at (1,5) in the body
 And the table "product-list" should have "511420" at (1,6) in the body
```

To this: 

```Gherkin
Then the table "product-list" should have the following values:
 | Name       | Jeans     |
 | Style      | Boot Cut  | 
 | Size       | 32x34     |
 | Price      | 13.00     |
 | Sale Price | 3.00      | 
 | SKU        | 511420    | 
```