### PR TITLE
Fix Element not having property since it was not found

### DIFF
--- a/features/FlexibleContext/assertFieldExists.feature
+++ b/features/FlexibleContext/assertFieldExists.feature
@@ -37,8 +37,8 @@ Feature:  Assert Fields exists
        | Pizza     |
        | Hamburger |
        | Hot Dog   |
-    Then I check "Pizza"
-    Then I check "Hamburger"
-    Then I check "Hot Dog"
+    When I check "Pizza"
+     And I check "Hamburger"
+     And I check "Hot Dog"
      And I press "Submit Favorites"
     Then I should see "Selected: Pizza, Hamburger, Hot Dog"

--- a/features/FlexibleContext/assertFieldExists.feature
+++ b/features/FlexibleContext/assertFieldExists.feature
@@ -1,0 +1,44 @@
+Feature:  Assert Fields exists
+  In order to ensure that select/checkbox elements exists
+  As a developer
+  I should have field exists assertions
+
+  Background:
+    Given I am on "/assert-field-exists.html"
+
+  Scenario: Developer Can Test for option in the select input
+    Then the "Texas" option exists in the State select
+
+  Scenario: Assertion fails reliably if option in select is not found
+    When I assert that the "Utopia" option exists in the State select
+    Then the assertion should throw an ExpectationException
+     And the assertion should fail with the message "The option 'Utopia' does not exist in the select"
+
+  Scenario: Assertion fails reliably if element is not found
+    When I assert that I should see the following fields:
+       | Utopia |
+    Then the assertion should throw an ExpectationException
+     And the assertion should fail with the message "No input label 'Utopia' found"
+
+  Scenario: Assertion fails reliably if checkbox element is not visible
+    When I assert that I should see the following fields:
+       | Kale Salad |
+    Then the assertion should throw an ExpectationException
+     And the assertion should fail with the message "No visible input found for 'Kale Salad'"
+
+  Scenario: Assertion fails reliably if checkbox element has no label
+    When I assert that I should see the following fields:
+       | Sushi |
+    Then the assertion should throw an ExpectationException
+     And the assertion should fail with the message "No input label 'Sushi' found"
+
+  Scenario: Developer Can Test for option with varying input/label setup
+    Then I should see the following fields:
+       | Pizza     |
+       | Hamburger |
+       | Hot Dog   |
+    Then I check "Pizza"
+    Then I check "Hamburger"
+    Then I check "Hot Dog"
+     And I press "Submit Favorites"
+    Then I should see "Selected: Pizza, Hamburger, Hot Dog"

--- a/features/bootstrap/FeatureContext.php
+++ b/features/bootstrap/FeatureContext.php
@@ -95,8 +95,9 @@ JS
      * Asserts that the prompt from ensureAlertExists returns the correct value.
      *
      * @Then /^the (?P<type>alert|confirm|prompt) should return (?P<value>.+)$/
-     * @param string $type   The type of popup to check results for.
-     * @param mixed  $result The expected result.
+     * @param  string               $type   The type of popup to check results for.
+     * @param  mixed                $result The expected result.
+     * @throws ExpectationException if the actual result does not match the expected results.
      */
     public function assertAlertResult($type, $result)
     {

--- a/src/Behat/FlexibleMink/Context/FlexibleContext.php
+++ b/src/Behat/FlexibleMink/Context/FlexibleContext.php
@@ -284,7 +284,9 @@ class FlexibleContext extends MinkContext
                 throw new ExpectationException("No input label '$fieldName' found", $this->getSession());
             }
             $name = $label->getAttribute('for');
-            $fields = [$context->findField($name)];
+            if (($element = $context->findField($name))) {
+                $fields = [$element];
+            }
         }
         if (count($fields) > 0) {
             foreach ($fields as $field) {
@@ -398,7 +400,7 @@ class FlexibleContext extends MinkContext
             throw new ExpectationException("The option '" . $option . "' exist in the select", $this->getSession());
         }
         if (!$existence && !$opt) {
-            throw new ExpectationException("The option '" . $option . "' not exist in the select", $this->getSession());
+            throw new ExpectationException("The option '" . $option . "' does not exist in the select", $this->getSession());
         }
     }
 

--- a/web/assert-field-exists.html
+++ b/web/assert-field-exists.html
@@ -1,0 +1,52 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Assert Field Exists</title>
+    <style type="text/css">
+        .hidden {
+            display: none;
+        }
+    </style>
+</head>
+<body>
+<h1>Assert Field Exists</h1>
+<section>
+    <form>
+        <label for="state">State</label>
+        <select id="state">
+            <option disabled selected>- Select State -</option>
+            <option>Texas</option>
+            <option>Not Texas</option>
+        </select>
+    </form>
+</section>
+<section>
+    <form onsubmit="foodSubmit(); return false;">
+        <h2>Favorite Foods</h2>
+        <label><input type="checkbox" name="favoriteFood" value="Pizza"> Pizza</label>
+        <input type="checkbox" name="favoriteFood" value="Sushi"> Sushi
+        <label for="Hamburger"><input type="checkbox" name="favoriteFood" value="Hamburger" id="Hamburger">
+            Hamburger</label>
+        <label for="Spaghetti"><input type="checkbox" name="favoriteFood" value="Spaghetti" id="Spaghetti">
+            Spaghetti</label>
+        <input type="checkbox" name="favoriteFood" value="Hot Dog" id="Hot Dog"> <label for="Hot Dog">Hot Dog</label>
+        <input type="checkbox" name="favoriteFood" value="Chocolate" id="Chocolate">
+            <label for="Chocolate">Chocolate</label>
+        <label class="hidden"><input type="checkbox" name="favoriteFood" value="Kale Salad"> Kale Salad</label>
+        <button type="submit">Submit Favorites</button>
+        <div id="foodSelected"></div>
+    </form>
+</section>
+<script>
+    function foodSubmit() {
+        var checkedElements = document.querySelectorAll('input[name="favoriteFood"]:checked');
+        var foods = [];
+        for (var i = 0; i < checkedElements.length; i++) {
+            foods.push(checkedElements[i].value);
+        }
+        document.getElementById('foodSelected').innerText = 'Selected: ' + foods.join(', ');
+    }
+</script>
+</body>
+</html>


### PR DESCRIPTION
# Issue 

A fatal error was being produced when a `<label>` element was found with the `for` attribute set without a corresponding element with the matching `id`. 

# Solution
Check if a corresponding element is found before adding it to the `fields` array.
