### PR TITLE
Fix ScreenShotContext namespace

### DIFF
--- a/src/Behat/FlexibleMink/Context/ScreenShotContext.php
+++ b/src/Behat/FlexibleMink/Context/ScreenShotContext.php
@@ -1,6 +1,9 @@
-<?php namespace Behat\FlexibleMink\PseudoInterface;
+<?php namespace Behat\FlexibleMink\Context;
 
 use Behat\Behat\Hook\Scope\AfterStepScope;
+use Behat\FlexibleMink\PseudoInterface\MinkContextInterface;
+use Behat\FlexibleMink\PseudoInterface\ScreenShotContextInterface;
+use Behat\FlexibleMink\PseudoInterface\TestArtifactContextInterface;
 use Behat\Mink\Exception\UnsupportedDriverActionException;
 use Behat\Testwork\Tester\Result\TestResult;
 

--- a/src/Behat/FlexibleMink/PseudoInterface/ScreenShotContextInterface.php
+++ b/src/Behat/FlexibleMink/PseudoInterface/ScreenShotContextInterface.php
@@ -1,6 +1,4 @@
-<?php
-
-namespace Behat\FlexibleMink\PseudoInterface;
+<?php namespace Behat\FlexibleMink\PseudoInterface;
 
 use Behat\Behat\Hook\Scope\AfterStepScope;
 


### PR DESCRIPTION
The namespace was set to PseudoInterface instead of Context for the
actual context class, even though it was in the proper Context folder, so
the trait couldn't be used properly.