### PR TITLE
add injectStoredValue to assertText(Not)InElement assertions

### DIFF
--- a/features/FlexibleContext/assertTextInElement.feature
+++ b/features/FlexibleContext/assertTextInElement.feature
@@ -12,12 +12,12 @@ Feature: Assert Element Contains Texts
   Scenario: Developer Can Assert Text Not Exist in Element
     Then I should not see "This is a div" in the "#emptyDiv" element
 
-  Scenario: Assertion fails reliably if text is not found in the element when excepted to be found
+  Scenario: Assertion fails reliably if text is not found in the element when expected to be found
     When I assert that I should not see "This is a div" in the "#divWithText" element
     Then the assertion should throw an ElementTextException
      And the assertion should fail with the message 'The text "This is a div" appears in the text of the element matching css "#divWithText", but it should not.'
 
-  Scenario: Assertion fails reliably if text is found in the element when excepted to be not found
+  Scenario: Assertion fails reliably if text is found in the element when expected to be not found
     When I assert that I should see "This is a div" in the "#emptyDiv" element
     Then the assertion should throw an ElementTextException
     And the assertion should fail with the message 'The text "This is a div" was not found in the text of the element matching css "#emptyDiv".'

--- a/features/FlexibleContext/assertTextInElement.feature
+++ b/features/FlexibleContext/assertTextInElement.feature
@@ -1,0 +1,32 @@
+Feature: Assert Element Contains Texts
+  In order to ensure that text appear in an element on the page
+  As a developer
+  I should be able to assert text in element
+
+  Background:
+    Given I am on "/assert-text-in-element.html"
+
+  Scenario: Developer Can Assert Text Exists in Element
+    Then I should see "This is a div" in the "#divWithText" element
+
+  Scenario: Developer Can Assert Text Not Exist in Element
+    Then I should not see "This is a div" in the "#emptyDiv" element
+
+  Scenario: Assertion fails reliably if text is not found in the element when excepted to be found
+    When I assert that I should not see "This is a div" in the "#divWithText" element
+    Then the assertion should throw an ElementTextException
+     And the assertion should fail with the message 'The text "This is a div" appears in the text of the element matching css "#divWithText", but it should not.'
+
+  Scenario: Assertion fails reliably if text is found in the element when excepted to be not found
+    When I assert that I should see "This is a div" in the "#emptyDiv" element
+    Then the assertion should throw an ElementTextException
+    And the assertion should fail with the message 'The text "This is a div" was not found in the text of the element matching css "#emptyDiv".'
+
+  Scenario: Assertion the text in element by injected value
+    Given the following is stored as "Page":
+      | first_div  | emptyDiv    |
+      | second_div | divWithText |
+      And the following is stored as "Content":
+        | text  | This is a div |
+     Then I should see "(the text of the Content)" in the "#(the second_div of the Page)" element
+      And I should not see "(the text of the Content)" in the "#(the first_div of the Page)" element

--- a/src/Behat/FlexibleMink/Context/FlexibleContext.php
+++ b/src/Behat/FlexibleMink/Context/FlexibleContext.php
@@ -126,8 +126,24 @@ class FlexibleContext extends MinkContext
      */
     public function assertElementContainsText($element, $text)
     {
+        $element = $this->injectStoredValues($element);
+        $text = $this->injectStoredValues($text);
+
         $this->waitFor(function () use ($element, $text) {
             parent::assertElementContainsText($element, $text);
+        });
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function assertElementNotContainsText($element, $text)
+    {
+        $element = $this->injectStoredValues($element);
+        $text = $this->injectStoredValues($text);
+
+        $this->waitFor(function () use ($element, $text) {
+            parent::assertElementNotContainsText($element, $text);
         });
     }
 

--- a/src/Behat/FlexibleMink/PseudoInterface/FlexibleContextInterface.php
+++ b/src/Behat/FlexibleMink/PseudoInterface/FlexibleContextInterface.php
@@ -93,6 +93,15 @@ trait FlexibleContextInterface
     abstract public function assertElementContainsText($element, $text);
 
     /**
+     * Checks, that element with specified CSS doesn't contain specified text.
+     *
+     * @see MinkContext::assertElementNotContainsText
+     * @param string|array $element css element selector.
+     * @param string       $text    expected text that should not being found.
+     */
+    abstract public function assertElementNotContainsText($element, $text);
+
+    /**
      * Clicks a visible link with specified id|title|alt|text.
      *
      * This method overrides the MinkContext::clickLink() default behavior for clickLink to ensure that only visible

--- a/web/assert-text-in-element.html
+++ b/web/assert-text-in-element.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <title>Text in Element for Flexible Mink</title>
+</head>
+
+<body>
+    <div id="emptyDiv"></div>
+    <div id="divWithText">This is a div</div>
+</body>
+
+</html>


### PR DESCRIPTION
This is going to add `injectStoreValue` to the `assertText(Not)InElement)` assertions, all related tests are also added.