### PR TITLE
Add waitFor to assertButtonDisabled

### DIFF
--- a/src/Behat/FlexibleMink/Context/FlexibleContext.php
+++ b/src/Behat/FlexibleMink/Context/FlexibleContext.php
@@ -197,25 +197,27 @@ class FlexibleContext extends MinkContext
             $disabled = 'disabled' == $disabled;
         }
 
-        $button = $this->getSession()->getPage()->findButton($locator);
+        $this->waitFor(function () use ($locator, $disabled) {
+            $button = $this->getSession()->getPage()->findButton($locator);
 
-        if (!$button) {
-            throw new ExpectationException("Could not find button for $locator", $this->getSession());
-        }
+            if (!$button) {
+                throw new ExpectationException("Could not find button for $locator", $this->getSession());
+            }
 
-        if ($button->hasAttribute('disabled')) {
-            if (!$disabled) {
+            if ($button->hasAttribute('disabled')) {
+                if (!$disabled) {
+                    throw new ExpectationException(
+                        "The button, $locator, was disabled, but it should not have been disabled.",
+                        $this->getSession()
+                    );
+                }
+            } elseif ($disabled) {
                 throw new ExpectationException(
-                    "The button, $locator, was disabled, but it should not have been disabled.",
+                    "The button, $locator, was not disabled, but it should have been disabled.",
                     $this->getSession()
                 );
             }
-        } elseif ($disabled) {
-            throw new ExpectationException(
-                "The button, $locator, was not disabled, but it should have been disabled.",
-                $this->getSession()
-            );
-        }
+        });
     }
 
     /**

--- a/src/Behat/FlexibleMink/Context/SpinnerContext.php
+++ b/src/Behat/FlexibleMink/Context/SpinnerContext.php
@@ -3,6 +3,7 @@
 namespace Behat\FlexibleMink\Context;
 
 use Behat\FlexibleMink\PseudoInterface\SpinnerContextInterface;
+use Exception;
 
 trait SpinnerContext
 {
@@ -14,7 +15,7 @@ trait SpinnerContext
      */
     public function waitFor(callable $lambda, $timeout = 30)
     {
-        $lastException = new \Exception(
+        $lastException = new Exception(
             'Timeout expired before a single try could be attempted. Is your timeout too short?'
         );
 
@@ -22,7 +23,7 @@ trait SpinnerContext
         while (time() - $start < $timeout) {
             try {
                 return $lambda();
-            } catch (\Exception $e) {
+            } catch (Exception $e) {
                 $lastException = $e;
             }
 


### PR DESCRIPTION
In the instance where a button becomes enabled/disabled as part of DOM manipulation via JS, if the function to change disable state is slow due to performance the wait will prevent it from immediately falling.