### PR TITLE
fix git cmd in circleci where missing a slash

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -10,7 +10,7 @@ machine:
 
 dependencies:
   override:
-    - git config --global user.email "ci@medology.com" && git config --global user.name "Circle CI" && git rebase origin master
+    - git config --global user.email "ci@medology.com" && git config --global user.name "Circle CI" && git rebase origin/master
     - cp ./docker/.env.example ./docker/.env
     - sudo pip install 'docker-compose==1.9.0'
     - sudo pip install 'six==1.10.0'


### PR DESCRIPTION
This is a fix for previous merged PR https://github.com/Medology/FlexibleMink/pull/100

A `/` is missed which end up change the current branch to _master_ 😥 