### PR TITLE
force circleci to fetch the origin

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -10,7 +10,7 @@ machine:
 
 dependencies:
   override:
-    - git config --global user.email "ci@medology.com" && git config --global user.name "Circle CI" && git rebase origin/master
+    - git fetch origin;git config --global user.email "ci@medology.com" && git config --global user.name "Circle CI" && git rebase origin/master
     - cp ./docker/.env.example ./docker/.env
     - sudo pip install 'docker-compose==1.9.0'
     - sudo pip install 'six==1.10.0'


### PR DESCRIPTION
For https://github.com/Medology/stdcheck.com/issues/2039

When rebuild the circle ci, it will try to use the cache. So this PR will force it to fetch the origin again.