### PR TITLE
Fix not see text assertion bug

### DIFF
--- a/features/FlexibleContext/assertTexts.feature
+++ b/features/FlexibleContext/assertTexts.feature
@@ -17,10 +17,13 @@ Feature: Assert Page Contains Texts
       | first_entry  | Line one   |
       | second_entry | Line two   |
       | third_entry  | Line three |
+      | fourth_entry | Line four  |
      Then I should see the following:
       | (the first entry of the list)  |
       | (the second entry of the list) |
       | (the third entry of the list)  |
+      And I should not see the following:
+      | (the fourth entry of the list)  |
 
   Scenario: Assertion fails reliably if a given line is not present
     When I assert that I should see the following:

--- a/src/Behat/FlexibleMink/Context/FlexibleContext.php
+++ b/src/Behat/FlexibleMink/Context/FlexibleContext.php
@@ -93,6 +93,7 @@ class FlexibleContext extends MinkContext
      */
     public function assertPageNotContainsText($text)
     {
+        $text = $this->injectStoredValues($text);
         $this->waitFor(function () use ($text) {
             parent::assertPageNotContainsText($text);
         });

--- a/src/Behat/FlexibleMink/Context/FlexibleContext.php
+++ b/src/Behat/FlexibleMink/Context/FlexibleContext.php
@@ -75,16 +75,20 @@ class FlexibleContext extends MinkContext
     /**
      * {@inheritdoc}
      *
-     * @Then I should see the following:
+     * @Then /^I should (?:|(?P<not>not ))see the following:$/
      */
-    public function assertPageContainsTexts(TableNode $table)
+    public function assertPageContainsTexts(TableNode $table, $not = null)
     {
         if (count($table->getRow(0)) > 1) {
             throw new InvalidArgumentException('Arguments must be a single-column list of items');
         }
 
         foreach ($table->getRows() as $text) {
-            $this->assertPageContainsText($text[0]);
+            if ($not) {
+                $this->assertPageNotContainsText($text[0]);
+            } else {
+                $this->assertPageContainsText($text[0]);
+            }
         }
     }
 

--- a/src/Behat/FlexibleMink/PseudoInterface/FlexibleContextInterface.php
+++ b/src/Behat/FlexibleMink/PseudoInterface/FlexibleContextInterface.php
@@ -31,9 +31,10 @@ trait FlexibleContextInterface
      * Asserts that the page contains a list of strings.
      *
      * @param  TableNode             $table The list of strings to find.
+     * @param  String                $not   A flag to assert not containing text.
      * @throws ResponseTextException If the text is not found.
      */
-    abstract public function assertPageContainsTexts(TableNode $table);
+    abstract public function assertPageContainsTexts(TableNode $table, $not = null);
 
     /**
      * This method overrides the MinkContext::assertPageAddress() default behavior by adding a waitFor to ensure that


### PR DESCRIPTION
For https://github.com/Medology/stdcheck.com/issues/3091

**Expected Behavior**
The post title should be asserted during the test

**Actual Behavior**
The `(the post_title of Post)` was literally searched for instead.

**Cause**
The injected store value was missing from the `assertNot` function.

**Resolution**
Add the injected store value.
