### PR TITLE
improve the table context to parse html select with selected option

### DIFF
--- a/features/TableContext.feature
+++ b/features/TableContext.feature
@@ -51,3 +51,11 @@ Feature: Table Context
       | Female Population | 412,064,436 |
     Then the assertion should throw an ExpectationException
      And the assertion should fail with the message "A row matching the supplied values could not be found."
+
+  Scenario: Developer Can Test for Row Contain HTML Select Input with Selected Option Parsed Correctly
+    Then the table "table-with-select" should have the following values:
+      | Name    | John |
+      | Country | US   |
+     And the table "table-with-select" should have the following values:
+      | Name    | Zhang |
+      | Country | China |

--- a/src/Behat/FlexibleMink/Context/TableContext.php
+++ b/src/Behat/FlexibleMink/Context/TableContext.php
@@ -173,7 +173,22 @@ trait TableContext
                 $cells = $row->findAll('xpath', '/td|/th');
 
                 for ($j = 0; $j < count($cells); $j++) {
+                    /** @var NodeElement $cell */
                     $cell = $cells[$j];
+
+                    //Handle select
+                    if (($options = $cell->findAll('xpath', '//option'))) {
+                        /** @var NodeElement $option */
+                        foreach ($options as $option) {
+                            if ($option->isSelected()) {
+                                $data[$i][$j] = trim($option->getText());
+
+                                break;
+                            }
+                        }
+
+                        continue;
+                    }
                     $data[$i][$j] = trim($cell->getText());
                 }
             }

--- a/web/table.html
+++ b/web/table.html
@@ -142,6 +142,35 @@
   </tbody>
     <tfoot></tfoot>
   </table>
+
+  <table id="table-with-select">
+    <thead>
+      <tr>
+        <th>Name</th>
+        <th>Country</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>John</td>
+        <td>
+          <select>
+            <option selected>US</option>
+            <option>China</option>
+          </select>
+        </td>
+      </tr>
+      <tr>
+        <td>Zhang</td>
+        <td>
+          <select>
+            <option>US</option>
+            <option selected>China</option>
+          </select>
+        </td>
+      </tr>
+    </tbody>
+  </table>
 </body>
 
 </html>


### PR DESCRIPTION
This will enable the `tableContext` to correctly parse the HTML select element with selected option item as a string.

Like the following `<table>`
![image](https://cloud.githubusercontent.com/assets/1442600/25107521/80b03890-2395-11e7-8321-040622e97630.png)

It has a column containing `<select><opiton></option>...</select>`

* Before this patch, the table is parsed as:

| Name | Country |
| --- | --- |
| John | US China|
| Zhang | US China |

* With this patched, the table will be parsed as:

| Name | Country |
| --- | --- |
| John | US |
| Zhang | China |
