### PR TITLE
add assertion for options in select

### DIFF
--- a/features/FlexibleContext/assertOptionInSelect.feature
+++ b/features/FlexibleContext/assertOptionInSelect.feature
@@ -1,0 +1,66 @@
+Feature:  Assert Option in Select
+  In order to ensure that select elements behave as expected
+  As a developer
+  I should have select behavior assertions
+
+  Background:
+    Given I am on "/select-option.html"
+
+  Scenario: Developer can assert select has matching options
+    Then the "Country" select should only have the following options:
+      | US     |
+      | China  |
+      | Canada |
+
+  Scenario: Assertion fails reliably if select has the same options but in the wrong order
+    When I assert that the "Country" select should only have the following options:
+      | China  |
+      | Canada |
+      | US     |
+    Then the assertion should throw an ExpectationException
+     And the assertion should fail with the message "Options in select match expected but not in expected order"
+
+  Scenario: Assertion fails reliably if select has less option than expected
+    When I assert that the "Country" select should only have the following options:
+      | US     |
+      | China  |
+      | Canada |
+      | Mexico |
+    Then the assertion should throw an ExpectationException
+     And the assertion should fail with the message "Select has less option then expected"
+
+  Scenario: Assertion fails reliably if select has more option than expected
+    When I assert that the "Country" select should only have the following options:
+      | US     |
+      | China  |
+    Then the assertion should throw an ExpectationException
+     And the assertion should fail with the message "Select has more option then expected"
+
+  Scenario: Assertion fails reliably if select has totally different option than expected
+    When I assert that the "Country" select should only have the following options:
+      | US     |
+      | China  |
+      | French |
+    Then the assertion should throw an ExpectationException
+     And the assertion should fail with the message "Expecting 3 matching option(s), found 2"
+
+  Scenario: Assertion fails reliably if select has totally different option than expected
+    When I assert that the "Country" select should only have the following options:
+      | Japan  |
+      | German |
+      | French |
+    Then the assertion should throw an ExpectationException
+     And the assertion should fail with the message "Expecting 3 matching option(s), found 0"
+
+  Scenario: Assertion fails reliably if no option in the select
+    When I assert that the "State" select should only have the following options:
+      | Texas |
+      | Ohio  |
+    Then the assertion should throw an ExpectationException
+     And the assertion should fail with the message "No option found in the select"
+
+  Scenario: Assertion fails reliably if option given in the wrong format
+    When I assert that the "State" select should only have the following options:
+     | Texas | Ohio |
+    Then the assertion should throw an InvalidArgumentException
+     And the assertion should fail with the message "Arguments must be a single-column list of items"

--- a/src/Behat/FlexibleMink/PseudoInterface/FlexibleContextInterface.php
+++ b/src/Behat/FlexibleMink/PseudoInterface/FlexibleContextInterface.php
@@ -229,6 +229,18 @@ trait FlexibleContextInterface
     abstract public function assertSelectContainsOption($select, $existence, $option);
 
     /**
+     * Assert if the options in the select match given options.
+     *
+     * @param string    $select    The name of the select
+     * @param TableNode $tableNode The text of the options.
+     *
+     * @throws ExpectationException     When there is no option in the select.
+     * @throws ExpectationException     When the option(s) in the select not match the option(s) listed.
+     * @throws InvalidArgumentException When no expected options listed in the test step.
+     */
+    abstract public function assertSelectContainsExactOptions($select, TableNode $tableNode);
+
+    /**
      * Attaches a local file to field with specified id|name|label|value. This is used when running behat and
      * browser session in different containers.
      *

--- a/web/select-option.html
+++ b/web/select-option.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Assert Option in Select</title>
+</head>
+<body>
+<h1>Select</h1>
+    <form>
+        <label for="country">Country</label>
+        <select id="country">
+            <option>US</option>
+            <option>China</option>
+            <option>Canada</option>
+        </select>
+        <label for="state">State</label>
+        <select id="state">
+        </select>
+    </form>
+</body>
+</html>


### PR DESCRIPTION
This will add assertion to assert that a form select(dropdown) control has the exact option items in the exact order listed in feature file.