### PR TITLE
Addition of overwrite to fill a field that is visible.

### DIFF
--- a/src/Behat/FlexibleMink/Context/FlexibleContext.php
+++ b/src/Behat/FlexibleMink/Context/FlexibleContext.php
@@ -182,6 +182,19 @@ class FlexibleContext extends MinkContext
     /**
      * {@inheritdoc}
      */
+    public function fillField($field, $value)
+    {
+        $field = $this->injectStoredValues($field);
+        $element = $this->waitFor(function () use ($field) {
+            return $this->assertVisibleOption($field);
+        });
+
+        $element->setValue($value);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function uncheckOption($locator)
     {
         $locator = $this->injectStoredValues($locator);

--- a/src/Behat/FlexibleMink/PseudoInterface/FlexibleContextInterface.php
+++ b/src/Behat/FlexibleMink/PseudoInterface/FlexibleContextInterface.php
@@ -123,6 +123,17 @@ trait FlexibleContextInterface
     abstract public function checkOption($locator);
 
     /**
+     * Clicks a visible field with specified id|title|alt|text.
+     *
+     * This method overrides the MinkContext::fillField() default behavior for fill a field to ensure that only visible
+     * field is filled.
+     * @see MinkContext::fillField
+     * @param string $field The id|title|alt|text of the field to be filled.
+     * @param string $value The value to be set on the field.
+     */
+    abstract public function fillField($field, $value);
+
+    /**
      * Unchecks checkbox with specified id|name|label|value.
      *
      * @see MinkContext::uncheckOption


### PR DESCRIPTION
This will make sure that the field that will be filled is a visible field by the user instead of selecting a fiend that might be hidden.