### PR TITLE
Make the cancelAlerts() only executing when there's active session

### DIFF
--- a/features/AlertContext.feature
+++ b/features/AlertContext.feature
@@ -1,3 +1,4 @@
+@clearAlertsWhenFinished
 Feature: Alert context
   In order to ensure that JavaScript alerts work as expected
   As a developer

--- a/features/AlertContext.feature
+++ b/features/AlertContext.feature
@@ -1,4 +1,3 @@
-@clearAlertsWhenFinished
 Feature: Alert context
   In order to ensure that JavaScript alerts work as expected
   As a developer

--- a/src/Behat/FlexibleMink/Context/AlertContext.php
+++ b/src/Behat/FlexibleMink/Context/AlertContext.php
@@ -20,11 +20,15 @@ trait AlertContext
     /**
      * Clears out any alerts or prompts that may be open.
      *
-     * @AfterScenario @clearAlertsWhenFinished
+     * @AfterScenario
      * @Given there are no alerts on the page
      */
     public function clearAlerts()
     {
+        if (!$this->getSession()->getDriver()->isStarted()) {
+            return;
+        }
+
         try {
             $this->cancelAlert();
         } catch (NoAlertOpenError $e) {

--- a/src/Behat/FlexibleMink/Context/AlertContext.php
+++ b/src/Behat/FlexibleMink/Context/AlertContext.php
@@ -20,7 +20,7 @@ trait AlertContext
     /**
      * Clears out any alerts or prompts that may be open.
      *
-     * @AfterScenario
+     * @AfterScenario @clearAlertsWhenFinished
      * @Given there are no alerts on the page
      */
     public function clearAlerts()


### PR DESCRIPTION
This is trying to improve the timeout problem that occurs frequently in other projects when tests in running in the selenium docker container.

### Cause
Becuase a `@AfterScenario` tag is added to the `cancelAlerts()` function, this function will be automatically executed after every scenario. Since there's no mechanism that behat can arrange the execution order of all `@AfterScneario` functions, when there is a function to clean the web driver session, and this function is executed before the `cancelAlerts()`, the `cancelAlerts()` will instantiate a new session and try to cancel the alerts. This newly created session will not be cleaned and it will be kept in WebDrive process across the test suite execution. Which slows down the chrome drive and causes the timeout.

### Implementation
* Disable the auto hook, or
* Clean the alert only if there's active session. https://github.com/Medology/FlexibleMink/pull/111#discussion_r121997591