### PR TITLE
make the clearAlerts() not called after scenario by default

### DIFF
--- a/features/AlertContext.feature
+++ b/features/AlertContext.feature
@@ -1,3 +1,4 @@
+@clearAlertsWhenFinished
 Feature: Alert context
   In order to ensure that JavaScript alerts work as expected
   As a developer

--- a/src/Behat/FlexibleMink/Context/AlertContext.php
+++ b/src/Behat/FlexibleMink/Context/AlertContext.php
@@ -20,7 +20,7 @@ trait AlertContext
     /**
      * Clears out any alerts or prompts that may be open.
      *
-     * @AfterScenario
+     * @AfterScenario @clearAlertsWhenFinished
      * @Given there are no alerts on the page
      */
     public function clearAlerts()


### PR DESCRIPTION
This is going to disabled the clearAlerts() function which tried at https://github.com/Medology/FlexibleMink/pull/111

### Issue
After we merged the last [PR](https://github.com/Medology/FlexibleMink/pull/111), behat still create a new session before `clearAlerts()` is called, which still keep the session is the memory.

### Fix
* The `clearAlerts()` will not be executed after scenario anymore.
* If the test left unexpected alert dialog when executing the test, it is supposed to be a failed test, which should not be automatically cleaned by the framework.