### PR TITLE
Added noun-store composer package.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,13 +16,20 @@
   },
   "require-dev": {
     "behat/mink-selenium2-driver": "*",
-    "phpunit/phpunit": "^4.8"
+    "phpunit/phpunit": "^4.8",
+    "chekote/noun-store": "dev-master"
   },
   "config": {
     "platform": {
       "php": "5.6.31"
     }
   },
+  "repositories": [
+    {
+      "type": "vcs",
+      "url": "https://github.com/Chekote/noun-store.git"
+    }
+  ],
   "autoload": {
     "psr-0": {
       "": "src/",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "d30bc28f10a45c9d831cc7300978d212",
-    "content-hash": "4db346abd4b8af112f6c06b904faa320",
+    "hash": "1710859f97607e75edaf619fce61670b",
+    "content-hash": "e14c3e5a5e4957c5ef3831acaefb5945",
     "packages": [
         {
             "name": "behat/behat",
@@ -1089,6 +1089,49 @@
             "time": "2016-03-05 09:10:18"
         },
         {
+            "name": "chekote/noun-store",
+            "version": "dev-master",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Chekote/noun-store.git",
+                "reference": "5c6143af5de8ca36519688014249a2b3230674e2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Chekote/noun-store/zipball/5c6143af5de8ca36519688014249a2b3230674e2",
+                "reference": "5c6143af5de8ca36519688014249a2b3230674e2",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.6.30"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^5.7"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-0": {
+                    "": [
+                        "src",
+                        "test"
+                    ]
+                }
+            },
+            "license": [
+                "MIT"
+            ],
+            "description": "Private STD Testing Services.",
+            "keywords": [
+                "noun",
+                "testing"
+            ],
+            "support": {
+                "source": "https://github.com/Chekote/noun-store/tree/master",
+                "issues": "https://github.com/Chekote/noun-store/issues"
+            },
+            "time": "2017-08-03 02:33:54"
+        },
+        {
             "name": "doctrine/instantiator",
             "version": "1.0.5",
             "source": {
@@ -2057,14 +2100,16 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {
+        "chekote/noun-store": 20
+    },
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=5.4"
+        "php": ">=5.6.31"
     },
     "platform-dev": [],
     "platform-overrides": {
-        "php": "5.4"
+        "php": "5.6.31"
     }
 }

--- a/features/bootstrap/FeatureContext.php
+++ b/features/bootstrap/FeatureContext.php
@@ -65,7 +65,7 @@ class FeatureContext implements Context, GathersContexts
      */
     public function putStoreStep($key, TableNode $attributes)
     {
-        $this->storeContext->put((object) ($attributes->getRowsHash()), $key);
+        $this->storeContext->set($key, (object) ($attributes->getRowsHash()));
     }
 
     /**
@@ -82,7 +82,7 @@ class FeatureContext implements Context, GathersContexts
             $value = $value->getRaw();
         }
 
-        $this->storeContext->put($value, $key);
+        $this->storeContext->set($key, $value);
     }
 
     /**

--- a/src/Medology/Behat/Mink/TableContext.php
+++ b/src/Medology/Behat/Mink/TableContext.php
@@ -91,7 +91,7 @@ class TableContext implements Context, GathersContexts
     protected function getTableFromName($name, $forceFresh = false)
     {
         // retrieve table from the store if it exists there
-        if ($this->storeContext->isStored($name) && !$forceFresh) {
+        if ($this->storeContext->has($name) && !$forceFresh) {
             return $this->storeContext->get($name);
         }
 
@@ -99,7 +99,7 @@ class TableContext implements Context, GathersContexts
         $table = $this->findNamedTable($name);
         $tableData = $this->buildTableFromHtml($table);
 
-        $this->storeContext->put($tableData, $name);
+        $this->storeContext->set($name, $tableData);
 
         return $tableData;
     }
@@ -232,7 +232,7 @@ class TableContext implements Context, GathersContexts
 
         // if a key name was provided, we can store this array for quick access next time
         if ($keyName) {
-            $this->storeContext->put($tableData, $keyName);
+            $this->storeContext->set($keyName, $tableData);
         }
 
         return $tableData;

--- a/src/Medology/Behat/Mink/WebDownloadContext.php
+++ b/src/Medology/Behat/Mink/WebDownloadContext.php
@@ -122,7 +122,7 @@ class WebDownloadContext implements Context, GathersContexts
         $response = curl_exec($ch);
 
         // Put response into object store.
-        $this->storeContext->put($response, $key);
+        $this->storeContext->set($key, $response);
 
         return $response;
     }

--- a/tests/Medology/Behat/StoreContextTest.php
+++ b/tests/Medology/Behat/StoreContextTest.php
@@ -53,7 +53,7 @@ class StoreContextTest extends PHPUnit_Framework_TestCase
 
         $testObj = $this->getMockObject();
         $name = 'testObj';
-        $this->storeContext->put($testObj, $name);
+        $this->storeContext->set($name, $testObj);
 
         /***********************
          * Validate First Argument
@@ -364,7 +364,7 @@ class StoreContextTest extends PHPUnit_Framework_TestCase
             ->with($this->equalTo('test_property_1'))
             ->willReturn('test_value_1');
 
-        $this->storeContext->put($mock, $name);
+        $this->storeContext->set($name, $mock);
 
         $this->assertEquals('test_value_1', $this->storeContext->injectStoredValues("(the test_property_1 of the $name)"));
     }


### PR DESCRIPTION
The noun-store package was written to allow projects to use the store functiontionality without having to pull in the entire FlexibleMink composer package. It was written initially for api.starfish.com.

I have removed the duplicate functionality from FlexibleMink and replaced it with the noun-store package.