### PR TITLE
Reduce duplication and clean up code.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 .idea/
-!.idea/php.xml
 
 /vendor/
 docker/.env

--- a/bin/behat
+++ b/bin/behat
@@ -20,11 +20,16 @@ register_shutdown_function('fatalHandler');
 
 define('BEHAT_BIN_PATH', __FILE__);
 
+/**
+ * Includes the specified file if it exists.
+ *
+ * @param  string $file the file to include.
+ * @return mixed  the value that the file returns.
+ */
 function includeIfExists($file)
 {
-    if (file_exists($file)) {
-        return include $file;
-    }
+    /** @noinspection PhpIncludeInspection no way to inspect a dynamic include */
+    return file_exists($file) ? include $file : false;
 }
 
 if (!$loader = includeIfExists(__DIR__.'/../vendor/autoload.php')) {

--- a/bin/containers
+++ b/bin/containers
@@ -14,6 +14,6 @@ else
 fi
 
 echo "Working on containers..."
-docker-compose -p $PROJECT_NAME \
+docker-compose -p ${PROJECT_NAME} \
     -f "$ROOT"/docker/docker-compose.yml \
     "$@"

--- a/dictionary.dic
+++ b/dictionary.dic
@@ -1,6 +1,12 @@
 colspan
 coords
+getcsv
 keypress
+Kudryashov
+Lazarecki
+Medology
+screenshot
+Serdyuk
 tbody
 tfoot
 thead

--- a/features/bootstrap/FeatureContext.php
+++ b/features/bootstrap/FeatureContext.php
@@ -10,8 +10,8 @@ use features\Extensions\Assertion\AssertionContext;
 use Medology\Behat\GathersContexts;
 use Medology\Behat\Mink\FlexibleContext;
 use Medology\Behat\Mink\WebDownloadContext;
-use Medology\Behat\StoreContext;
 use Medology\Behat\TypeCaster;
+use Medology\Behat\UsesStoreContext;
 use Medology\Spinner;
 
 class FeatureContext implements Context, GathersContexts
@@ -19,12 +19,10 @@ class FeatureContext implements Context, GathersContexts
     // Depends
     use AssertionContext;
     use TypeCaster;
+    use UsesStoreContext;
 
     /** @var FlexibleContext */
     protected $flexibleContext;
-
-    /** @var StoreContext */
-    protected $storeContext;
 
     /** @var WebDownloadContext */
     protected $webDownloadContext;
@@ -45,10 +43,6 @@ class FeatureContext implements Context, GathersContexts
 
         if (!$this->flexibleContext = $environment->getContext(FlexibleContext::class)) {
             throw new RuntimeException('Failed to gather FlexibleContext');
-        }
-
-        if (!$this->storeContext = $environment->getContext(StoreContext::class)) {
-            throw new RuntimeException('Failed to gather StoreContext');
         }
 
         if (!$this->webDownloadContext = $environment->getContext(WebDownloadContext::class)) {

--- a/features/bootstrap/FeatureContext.php
+++ b/features/bootstrap/FeatureContext.php
@@ -1,48 +1,24 @@
 <?php
 
 use Behat\Behat\Context\Context;
-use Behat\Behat\Context\Environment\InitializedContextEnvironment;
-use Behat\Behat\Hook\Scope\BeforeScenarioScope;
 use Behat\Gherkin\Node\PyStringNode;
 use Behat\Gherkin\Node\TableNode;
 use Behat\Mink\Exception\ExpectationException;
 use features\Extensions\Assertion\AssertionContext;
-use Medology\Behat\GathersContexts;
 use Medology\Behat\Mink\UsesFlexibleContext;
-use Medology\Behat\Mink\WebDownloadContext;
+use Medology\Behat\Mink\UsesWebDownloadContext;
 use Medology\Behat\TypeCaster;
 use Medology\Behat\UsesStoreContext;
 use Medology\Spinner;
 
-class FeatureContext implements Context, GathersContexts
+class FeatureContext implements Context
 {
     // Depends
     use AssertionContext;
     use TypeCaster;
     use UsesFlexibleContext;
     use UsesStoreContext;
-
-    /** @var WebDownloadContext */
-    protected $webDownloadContext;
-
-    /**
-     * {@inheritdoc}
-     */
-    public function gatherContexts(BeforeScenarioScope $scope)
-    {
-        $environment = $scope->getEnvironment();
-
-        if (!($environment instanceof InitializedContextEnvironment)) {
-            throw new RuntimeException(
-                'Expected Environment to be ' . InitializedContextEnvironment::class .
-                    ', but got ' . get_class($environment)
-          );
-        }
-
-        if (!$this->webDownloadContext = $environment->getContext(WebDownloadContext::class)) {
-            throw new RuntimeException('Failed to gather WebDownloadContext');
-        }
-    }
+    use UsesWebDownloadContext;
 
     /**
      * Places an object with the given structure into the store.

--- a/features/bootstrap/FeatureContext.php
+++ b/features/bootstrap/FeatureContext.php
@@ -8,7 +8,7 @@ use Behat\Gherkin\Node\TableNode;
 use Behat\Mink\Exception\ExpectationException;
 use features\Extensions\Assertion\AssertionContext;
 use Medology\Behat\GathersContexts;
-use Medology\Behat\Mink\FlexibleContext;
+use Medology\Behat\Mink\UsesFlexibleContext;
 use Medology\Behat\Mink\WebDownloadContext;
 use Medology\Behat\TypeCaster;
 use Medology\Behat\UsesStoreContext;
@@ -19,10 +19,8 @@ class FeatureContext implements Context, GathersContexts
     // Depends
     use AssertionContext;
     use TypeCaster;
+    use UsesFlexibleContext;
     use UsesStoreContext;
-
-    /** @var FlexibleContext */
-    protected $flexibleContext;
 
     /** @var WebDownloadContext */
     protected $webDownloadContext;
@@ -39,10 +37,6 @@ class FeatureContext implements Context, GathersContexts
                 'Expected Environment to be ' . InitializedContextEnvironment::class .
                     ', but got ' . get_class($environment)
           );
-        }
-
-        if (!$this->flexibleContext = $environment->getContext(FlexibleContext::class)) {
-            throw new RuntimeException('Failed to gather FlexibleContext');
         }
 
         if (!$this->webDownloadContext = $environment->getContext(WebDownloadContext::class)) {

--- a/src/Medology/Behat/CsvContext.php
+++ b/src/Medology/Behat/CsvContext.php
@@ -3,41 +3,17 @@
 namespace Medology\Behat;
 
 use Behat\Behat\Context\Context;
-use Behat\Behat\Context\Environment\InitializedContextEnvironment;
-use Behat\Behat\Hook\Scope\BeforeScenarioScope;
 use Behat\Gherkin\Node\TableNode;
 use Exception;
-use Medology\Behat\Mink\FlexibleContext;
-use RuntimeException;
+use Medology\Behat\Mink\UsesFlexibleContext;
 
 /**
  * Provides functionality for working with CSV data.
  */
-class CsvContext implements Context, GathersContexts
+class CsvContext implements Context
 {
+    use UsesFlexibleContext;
     use UsesStoreContext;
-
-    /** @var FlexibleContext */
-    protected $flexibleContext;
-
-    /**
-     * {@inheritdoc}
-     */
-    public function gatherContexts(BeforeScenarioScope $scope)
-    {
-        $environment = $scope->getEnvironment();
-
-        if (!($environment instanceof InitializedContextEnvironment)) {
-            throw new RuntimeException(
-                'Expected Environment to be ' . InitializedContextEnvironment::class .
-                    ', but got ' . get_class($environment)
-          );
-        }
-
-        if (!$this->flexibleContext = $environment->getContext(FlexibleContext::class)) {
-            throw new RuntimeException('Failed to gather FlexibleContext');
-        }
-    }
 
     /**
      * Ensures that the given variable in the store is a CSV containing the given rows.

--- a/src/Medology/Behat/CsvContext.php
+++ b/src/Medology/Behat/CsvContext.php
@@ -15,11 +15,10 @@ use RuntimeException;
  */
 class CsvContext implements Context, GathersContexts
 {
+    use UsesStoreContext;
+
     /** @var FlexibleContext */
     protected $flexibleContext;
-
-    /** @var StoreContext */
-    protected $storeContext;
 
     /**
      * {@inheritdoc}
@@ -37,10 +36,6 @@ class CsvContext implements Context, GathersContexts
 
         if (!$this->flexibleContext = $environment->getContext(FlexibleContext::class)) {
             throw new RuntimeException('Failed to gather FlexibleContext');
-        }
-
-        if (!$this->storeContext = $environment->getContext(StoreContext::class)) {
-            throw new RuntimeException('Failed to gather StoreContext');
         }
     }
 

--- a/src/Medology/Behat/Mink/AlertContext.php
+++ b/src/Medology/Behat/Mink/AlertContext.php
@@ -3,14 +3,10 @@
 namespace Medology\Behat\Mink;
 
 use Behat\Behat\Context\Context;
-use Behat\Behat\Context\Environment\InitializedContextEnvironment;
-use Behat\Behat\Hook\Scope\BeforeScenarioScope;
 use Behat\Mink\Driver\Selenium2Driver;
 use Behat\Mink\Exception\ExpectationException;
 use Behat\Mink\Exception\UnsupportedDriverActionException;
-use Medology\Behat\GathersContexts;
 use Medology\Spinner;
-use RuntimeException;
 use WebDriver\Exception\NoAlertOpenError;
 
 /**
@@ -18,29 +14,9 @@ use WebDriver\Exception\NoAlertOpenError;
  *
  * @link https://gist.github.com/blazarecki/2888851
  */
-class AlertContext implements Context, GathersContexts
+class AlertContext implements Context
 {
-    /** @var FlexibleContext */
-    protected $flexibleContext;
-
-    /**
-     * {@inheritdoc}
-     */
-    public function gatherContexts(BeforeScenarioScope $scope)
-    {
-        $environment = $scope->getEnvironment();
-
-        if (!($environment instanceof InitializedContextEnvironment)) {
-            throw new RuntimeException(
-                'Expected Environment to be ' . InitializedContextEnvironment::class .
-                    ', but got ' . get_class($environment)
-          );
-        }
-
-        if (!$this->flexibleContext = $environment->getContext(FlexibleContext::class)) {
-            throw new RuntimeException('Failed to gather FlexibleContext');
-        }
-    }
+    use UsesFlexibleContext;
 
     /**
      * Clears out any alerts or prompts that may be open.

--- a/src/Medology/Behat/Mink/FlexibleContext.php
+++ b/src/Medology/Behat/Mink/FlexibleContext.php
@@ -2,8 +2,6 @@
 
 namespace Medology\Behat\Mink;
 
-use Behat\Behat\Context\Environment\InitializedContextEnvironment;
-use Behat\Behat\Hook\Scope\BeforeScenarioScope;
 use Behat\Gherkin\Node\TableNode;
 use Behat\Mink\Driver\Selenium2Driver;
 use Behat\Mink\Element\NodeElement;
@@ -15,20 +13,19 @@ use Behat\Mink\Exception\ResponseTextException;
 use Behat\Mink\Exception\UnsupportedDriverActionException;
 use Behat\MinkExtension\Context\MinkContext;
 use InvalidArgumentException;
-use Medology\Behat\GathersContexts;
-use Medology\Behat\StoreContext;
 use Medology\Behat\TypeCaster;
+use Medology\Behat\UsesStoreContext;
 use Medology\Spinner;
-use RuntimeException;
 use ZipArchive;
 
 /**
  * Overwrites some MinkContext step definitions to make them more resilient to failures caused by browser/driver
  * discrepancies and unpredictable load times.
  */
-class FlexibleContext extends MinkContext implements GathersContexts
+class FlexibleContext extends MinkContext
 {
     use TypeCaster;
+    use UsesStoreContext;
 
     /** @var array map of common key names to key codes */
     protected static $keyCodes = [
@@ -38,28 +35,6 @@ class FlexibleContext extends MinkContext implements GathersContexts
         'shift tab'  => 2228233,
         'tab'        => 9,
     ];
-
-    /** @var StoreContext */
-    protected $storeContext;
-
-    /**
-     * {@inheritdoc}
-     */
-    public function gatherContexts(BeforeScenarioScope $scope)
-    {
-        $environment = $scope->getEnvironment();
-
-        if (!($environment instanceof InitializedContextEnvironment)) {
-            throw new RuntimeException(
-                'Expected Environment to be ' . InitializedContextEnvironment::class .
-                    ', but got ' . get_class($environment)
-          );
-        }
-
-        if (!$this->storeContext = $environment->getContext(StoreContext::class)) {
-            throw new RuntimeException('Failed to gather StoreContext');
-        }
-    }
 
     /**
      * This method overrides the MinkContext::assertPageContainsText() default behavior for assertFieldContains to

--- a/src/Medology/Behat/Mink/FlexibleContext.php
+++ b/src/Medology/Behat/Mink/FlexibleContext.php
@@ -638,9 +638,10 @@ class FlexibleContext extends MinkContext
      * Attaches a local file to field with specified id|name|label|value. This is used when running behat and
      * browser session in different containers.
      *
-     * @When /^(?:|I )attach the local file "(?P<path>[^"]*)" to "(?P<field>(?:[^"]|\\")*)"$/
-     * @param string $field The file field to select the file with
-     * @param string $path  The local path of the file
+     * @When   /^(?:|I )attach the local file "(?P<path>[^"]*)" to "(?P<field>(?:[^"]|\\")*)"$/
+     * @param  string                           $field The file field to select the file with
+     * @param  string                           $path  The local path of the file
+     * @throws UnsupportedDriverActionException if getWebDriverSession() is not supported by the current driver.
      */
     public function addLocalFileToField($path, $field)
     {
@@ -660,7 +661,13 @@ class FlexibleContext extends MinkContext
         $zip->addFile($path, basename($path));
         $zip->close();
 
-        $remotePath = $this->getSession()->getDriver()->getWebDriverSession()->file([
+        $driver = $this->getSession()->getDriver();
+        if (!($driver instanceof Selenium2Driver)) {
+            throw new UnsupportedDriverActionException('getWebDriverSession() is not supported by %s', $driver);
+        }
+
+        /** @noinspection PhpUndefinedMethodInspection file() method annotation is missing from WebDriver\Session */
+        $remotePath = $driver->getWebDriverSession()->file([
             'file' => base64_encode(file_get_contents($tempZip)),
         ]);
 

--- a/src/Medology/Behat/Mink/JavaScriptContext.php
+++ b/src/Medology/Behat/Mink/JavaScriptContext.php
@@ -7,7 +7,7 @@ use Behat\Gherkin\Node\TableNode;
 use Behat\Mink\Exception\ExpectationException;
 
 /**
- * {@inheritdoc}
+ * Provides functionality modifying and checking the Javascript environment in the browser.
  */
 class JavaScriptContext implements Context
 {

--- a/src/Medology/Behat/Mink/JavaScriptContext.php
+++ b/src/Medology/Behat/Mink/JavaScriptContext.php
@@ -3,39 +3,15 @@
 namespace Medology\Behat\Mink;
 
 use Behat\Behat\Context\Context;
-use Behat\Behat\Context\Environment\InitializedContextEnvironment;
-use Behat\Behat\Hook\Scope\BeforeScenarioScope;
 use Behat\Gherkin\Node\TableNode;
 use Behat\Mink\Exception\ExpectationException;
-use Medology\Behat\GathersContexts;
-use RuntimeException;
 
 /**
  * {@inheritdoc}
  */
-class JavaScriptContext implements Context, GathersContexts
+class JavaScriptContext implements Context
 {
-    /** @var FlexibleContext */
-    protected $flexibleContext;
-
-    /**
-     * {@inheritdoc}
-     */
-    public function gatherContexts(BeforeScenarioScope $scope)
-    {
-        $environment = $scope->getEnvironment();
-
-        if (!($environment instanceof InitializedContextEnvironment)) {
-            throw new RuntimeException(
-                'Expected Environment to be ' . InitializedContextEnvironment::class .
-                    ', but got ' . get_class($environment)
-          );
-        }
-
-        if (!$this->flexibleContext = $environment->getContext(FlexibleContext::class)) {
-            throw new RuntimeException('Failed to gather FlexibleContext');
-        }
-    }
+    use UsesFlexibleContext;
 
     /**
      * Determines if a javascript variable is set and has a value.

--- a/src/Medology/Behat/Mink/ScreenShotContext.php
+++ b/src/Medology/Behat/Mink/ScreenShotContext.php
@@ -3,42 +3,18 @@
 namespace Medology\Behat\Mink;
 
 use Behat\Behat\Context\Context;
-use Behat\Behat\Context\Environment\InitializedContextEnvironment;
 use Behat\Behat\Hook\Scope\AfterStepScope;
-use Behat\Behat\Hook\Scope\BeforeScenarioScope;
 use Behat\Mink\Exception\UnsupportedDriverActionException;
 use Behat\Testwork\Tester\Result\TestResult;
-use Medology\Behat\GathersContexts;
-use RuntimeException;
 
 /**
  * Context for capturing screenshots of the web browser.
  *
  * Note: Only works with Mink drivers that support the getScreenshot() method.
  */
-class ScreenShotContext implements Context, GathersContexts
+class ScreenShotContext implements Context
 {
-    /** @var FlexibleContext */
-    protected $flexibleContext;
-
-    /**
-     * {@inheritdoc}
-     */
-    public function gatherContexts(BeforeScenarioScope $scope)
-    {
-        $environment = $scope->getEnvironment();
-
-        if (!($environment instanceof InitializedContextEnvironment)) {
-            throw new RuntimeException(
-                'Expected Environment to be ' . InitializedContextEnvironment::class .
-                    ', but got ' . get_class($environment)
-          );
-        }
-
-        if (!$this->flexibleContext = $environment->getContext(FlexibleContext::class)) {
-            throw new RuntimeException('Failed to gather FlexibleContext');
-        }
-    }
+    use UsesFlexibleContext;
 
     /**
      * Captures a screenshot and saves it to the artifacts directory.

--- a/src/Medology/Behat/Mink/TableContext.php
+++ b/src/Medology/Behat/Mink/TableContext.php
@@ -11,7 +11,7 @@ use Behat\Mink\Exception\ElementNotFoundException;
 use Behat\Mink\Exception\ExpectationException;
 use InvalidArgumentException;
 use Medology\Behat\GathersContexts;
-use Medology\Behat\StoreContext;
+use Medology\Behat\UsesStoreContext;
 use Medology\Spinner;
 use RuntimeException;
 
@@ -20,8 +20,7 @@ use RuntimeException;
  */
 class TableContext implements Context, GathersContexts
 {
-    /** @var StoreContext */
-    protected $storeContext;
+    use UsesStoreContext;
 
     /** @var FlexibleContext */
     protected $flexibleContext;
@@ -38,10 +37,6 @@ class TableContext implements Context, GathersContexts
                 'Expected Environment to be ' . InitializedContextEnvironment::class .
                     ', but got ' . get_class($environment)
           );
-        }
-
-        if (!$this->storeContext = $environment->getContext(StoreContext::class)) {
-            throw new RuntimeException('Failed to gather StoreContext');
         }
 
         if (!$this->flexibleContext = $environment->getContext(FlexibleContext::class)) {

--- a/src/Medology/Behat/Mink/TableContext.php
+++ b/src/Medology/Behat/Mink/TableContext.php
@@ -3,14 +3,11 @@
 namespace Medology\Behat\Mink;
 
 use Behat\Behat\Context\Context;
-use Behat\Behat\Context\Environment\InitializedContextEnvironment;
-use Behat\Behat\Hook\Scope\BeforeScenarioScope;
 use Behat\Gherkin\Node\TableNode;
 use Behat\Mink\Element\NodeElement;
 use Behat\Mink\Exception\ElementNotFoundException;
 use Behat\Mink\Exception\ExpectationException;
 use InvalidArgumentException;
-use Medology\Behat\GathersContexts;
 use Medology\Behat\UsesStoreContext;
 use Medology\Spinner;
 use RuntimeException;
@@ -18,31 +15,10 @@ use RuntimeException;
 /**
  * Class TableContext.
  */
-class TableContext implements Context, GathersContexts
+class TableContext implements Context
 {
+    use UsesFlexibleContext;
     use UsesStoreContext;
-
-    /** @var FlexibleContext */
-    protected $flexibleContext;
-
-    /**
-     * {@inheritdoc}
-     */
-    public function gatherContexts(BeforeScenarioScope $scope)
-    {
-        $environment = $scope->getEnvironment();
-
-        if (!($environment instanceof InitializedContextEnvironment)) {
-            throw new RuntimeException(
-                'Expected Environment to be ' . InitializedContextEnvironment::class .
-                    ', but got ' . get_class($environment)
-          );
-        }
-
-        if (!$this->flexibleContext = $environment->getContext(FlexibleContext::class)) {
-            throw new RuntimeException('Failed to gather FlexibleContext');
-        }
-    }
 
     /**
      * Finds a table with a given data-qa-id, name, or id. data-qa-id is given preference and matched exactly, while

--- a/src/Medology/Behat/Mink/UsesAlertContext.php
+++ b/src/Medology/Behat/Mink/UsesAlertContext.php
@@ -1,0 +1,38 @@
+<?php namespace Medology\Behat\Mink;
+
+use Behat\Behat\Context\Environment\InitializedContextEnvironment;
+use Behat\Behat\Hook\Scope\BeforeScenarioScope;
+use RuntimeException;
+
+/**
+ * Trait that grants access to the AlertContext instance via $this->alertContext.
+ */
+trait UsesAlertContext
+{
+    /** @var AlertContext */
+    protected $alertContext;
+
+    /**
+     * Gathers the AlertContext instance and stores a reference in $this->alertContext.
+     *
+     * @param  BeforeScenarioScope $scope
+     * @throws RuntimeException    If the current environment is not initialized.
+     * @return void
+     * @BeforeScenario
+     */
+    public function gatherAlertContext(BeforeScenarioScope $scope)
+    {
+        $environment = $scope->getEnvironment();
+
+        if (!($environment instanceof InitializedContextEnvironment)) {
+            throw new RuntimeException(
+                'Expected Environment to be ' . InitializedContextEnvironment::class .
+                ', but got ' . get_class($environment)
+            );
+        }
+
+        if (!$this->alertContext = $environment->getContext(AlertContext::class)) {
+            throw new RuntimeException('Failed to gather AlertContext');
+        }
+    }
+}

--- a/src/Medology/Behat/Mink/UsesFlexibleContext.php
+++ b/src/Medology/Behat/Mink/UsesFlexibleContext.php
@@ -1,0 +1,38 @@
+<?php namespace Medology\Behat\Mink;
+
+use Behat\Behat\Context\Environment\InitializedContextEnvironment;
+use Behat\Behat\Hook\Scope\BeforeScenarioScope;
+use RuntimeException;
+
+/**
+ * Trait that grants access to the FlexibleContext instance via $this->flexibleContext.
+ */
+trait UsesFlexibleContext
+{
+    /** @var FlexibleContext */
+    protected $flexibleContext;
+
+    /**
+     * Gathers the FlexibleContext instance and stores a reference in $this->flexibleContext.
+     *
+     * @param  BeforeScenarioScope $scope
+     * @throws RuntimeException    If the current environment is not initialized.
+     * @return void
+     * @BeforeScenario
+     */
+    public function gatherFlexibleContext(BeforeScenarioScope $scope)
+    {
+        $environment = $scope->getEnvironment();
+
+        if (!($environment instanceof InitializedContextEnvironment)) {
+            throw new RuntimeException(
+                'Expected Environment to be ' . InitializedContextEnvironment::class .
+                ', but got ' . get_class($environment)
+            );
+        }
+
+        if (!$this->flexibleContext = $environment->getContext(FlexibleContext::class)) {
+            throw new RuntimeException('Failed to gather FlexibleContext');
+        }
+    }
+}

--- a/src/Medology/Behat/Mink/UsesJavaScriptContext.php
+++ b/src/Medology/Behat/Mink/UsesJavaScriptContext.php
@@ -1,0 +1,38 @@
+<?php namespace Medology\Behat\Mink;
+
+use Behat\Behat\Context\Environment\InitializedContextEnvironment;
+use Behat\Behat\Hook\Scope\BeforeScenarioScope;
+use RuntimeException;
+
+/**
+ * Trait that grants access to the JavaScriptContext instance via $this->javaScriptContext.
+ */
+trait UsesJavaScriptContext
+{
+    /** @var JavaScriptContext */
+    protected $javaScriptContext;
+
+    /**
+     * Gathers the JavaScriptContext instance and stores a reference in $this->javaScriptContext.
+     *
+     * @param  BeforeScenarioScope $scope
+     * @throws RuntimeException    If the current environment is not initialized.
+     * @return void
+     * @BeforeScenario
+     */
+    public function gatherJavaScriptContext(BeforeScenarioScope $scope)
+    {
+        $environment = $scope->getEnvironment();
+
+        if (!($environment instanceof InitializedContextEnvironment)) {
+            throw new RuntimeException(
+                'Expected Environment to be ' . InitializedContextEnvironment::class .
+                ', but got ' . get_class($environment)
+            );
+        }
+
+        if (!$this->javaScriptContext = $environment->getContext(JavaScriptContext::class)) {
+            throw new RuntimeException('Failed to gather JavaScriptContext');
+        }
+    }
+}

--- a/src/Medology/Behat/Mink/UsesScreenShotContext.php
+++ b/src/Medology/Behat/Mink/UsesScreenShotContext.php
@@ -1,0 +1,38 @@
+<?php namespace Medology\Behat\Mink;
+
+use Behat\Behat\Context\Environment\InitializedContextEnvironment;
+use Behat\Behat\Hook\Scope\BeforeScenarioScope;
+use RuntimeException;
+
+/**
+ * Trait that grants access to the ScreenShotContext instance via $this->screenShotContext.
+ */
+trait UsesScreenShotContext
+{
+    /** @var ScreenShotContext */
+    protected $screenShotContext;
+
+    /**
+     * Gathers the ScreenShotContext instance and stores a reference in $this->screenShotContext.
+     *
+     * @param  BeforeScenarioScope $scope
+     * @throws RuntimeException    If the current environment is not initialized.
+     * @return void
+     * @BeforeScenario
+     */
+    public function gatherScreenShotContext(BeforeScenarioScope $scope)
+    {
+        $environment = $scope->getEnvironment();
+
+        if (!($environment instanceof InitializedContextEnvironment)) {
+            throw new RuntimeException(
+                'Expected Environment to be ' . InitializedContextEnvironment::class .
+                ', but got ' . get_class($environment)
+            );
+        }
+
+        if (!$this->screenShotContext = $environment->getContext(ScreenShotContext::class)) {
+            throw new RuntimeException('Failed to gather ScreenShotContext');
+        }
+    }
+}

--- a/src/Medology/Behat/Mink/UsesTableContext.php
+++ b/src/Medology/Behat/Mink/UsesTableContext.php
@@ -1,0 +1,38 @@
+<?php namespace Medology\Behat\Mink;
+
+use Behat\Behat\Context\Environment\InitializedContextEnvironment;
+use Behat\Behat\Hook\Scope\BeforeScenarioScope;
+use RuntimeException;
+
+/**
+ * Trait that grants access to the TableContext instance via $this->tableContext.
+ */
+trait UsesTableContext
+{
+    /** @var TableContext */
+    protected $tableContext;
+
+    /**
+     * Gathers the TableContext instance and stores a reference in $this->tableContext.
+     *
+     * @param  BeforeScenarioScope $scope
+     * @throws RuntimeException    If the current environment is not initialized.
+     * @return void
+     * @BeforeScenario
+     */
+    public function gatherTableContext(BeforeScenarioScope $scope)
+    {
+        $environment = $scope->getEnvironment();
+
+        if (!($environment instanceof InitializedContextEnvironment)) {
+            throw new RuntimeException(
+                'Expected Environment to be ' . InitializedContextEnvironment::class .
+                ', but got ' . get_class($environment)
+            );
+        }
+
+        if (!$this->tableContext = $environment->getContext(TableContext::class)) {
+            throw new RuntimeException('Failed to gather TableContext');
+        }
+    }
+}

--- a/src/Medology/Behat/Mink/UsesWebDownloadContext.php
+++ b/src/Medology/Behat/Mink/UsesWebDownloadContext.php
@@ -1,0 +1,38 @@
+<?php namespace Medology\Behat\Mink;
+
+use Behat\Behat\Context\Environment\InitializedContextEnvironment;
+use Behat\Behat\Hook\Scope\BeforeScenarioScope;
+use RuntimeException;
+
+/**
+ * Trait that grants access to the WebDownloadContext instance via $this->webDownloadContext.
+ */
+trait UsesWebDownloadContext
+{
+    /** @var WebDownloadContext */
+    protected $webDownloadContext;
+
+    /**
+     * Gathers the WebDownloadContext instance and stores a reference in $this->webDownloadContext.
+     *
+     * @param  BeforeScenarioScope $scope
+     * @throws RuntimeException    If the current environment is not initialized.
+     * @return void
+     * @BeforeScenario
+     */
+    public function gatherWebDownloadContext(BeforeScenarioScope $scope)
+    {
+        $environment = $scope->getEnvironment();
+
+        if (!($environment instanceof InitializedContextEnvironment)) {
+            throw new RuntimeException(
+                'Expected Environment to be ' . InitializedContextEnvironment::class .
+                ', but got ' . get_class($environment)
+            );
+        }
+
+        if (!$this->webDownloadContext = $environment->getContext(WebDownloadContext::class)) {
+            throw new RuntimeException('Failed to gather WebDownloadContext');
+        }
+    }
+}

--- a/src/Medology/Behat/Mink/WebDownloadContext.php
+++ b/src/Medology/Behat/Mink/WebDownloadContext.php
@@ -9,7 +9,7 @@ use Behat\Mink\Exception\ElementNotFoundException;
 use Behat\Mink\Exception\ExpectationException;
 use Exception;
 use Medology\Behat\GathersContexts;
-use Medology\Behat\StoreContext;
+use Medology\Behat\UsesStoreContext;
 use Medology\Spinner;
 use RuntimeException;
 
@@ -18,13 +18,12 @@ use RuntimeException;
  */
 class WebDownloadContext implements Context, GathersContexts
 {
+    use UsesStoreContext;
+
     protected static $baseUrlRegExp = '/^((http(s|):[\/]{2}|)([a-zA-Z]+\.|)[a-zA-Z0-9]+\.[a-zA-Z]+(\:[\d]+|)|[a-zA-Z0-9]+)/';
 
     /** @var FlexibleContext */
     protected $flexibleContext;
-
-    /** @var StoreContext */
-    protected $storeContext;
 
     /**
      * {@inheritdoc}
@@ -38,10 +37,6 @@ class WebDownloadContext implements Context, GathersContexts
                 'Expected Environment to be ' . InitializedContextEnvironment::class .
                     ', but got ' . get_class($environment)
           );
-        }
-
-        if (!$this->storeContext = $environment->getContext(StoreContext::class)) {
-            throw new RuntimeException('Failed to gather StoreContext');
         }
 
         if (!$this->flexibleContext = $environment->getContext(FlexibleContext::class)) {

--- a/src/Medology/Behat/Mink/WebDownloadContext.php
+++ b/src/Medology/Behat/Mink/WebDownloadContext.php
@@ -3,46 +3,21 @@
 namespace Medology\Behat\Mink;
 
 use Behat\Behat\Context\Context;
-use Behat\Behat\Context\Environment\InitializedContextEnvironment;
-use Behat\Behat\Hook\Scope\BeforeScenarioScope;
 use Behat\Mink\Exception\ElementNotFoundException;
 use Behat\Mink\Exception\ExpectationException;
 use Exception;
-use Medology\Behat\GathersContexts;
 use Medology\Behat\UsesStoreContext;
 use Medology\Spinner;
-use RuntimeException;
 
 /**
  * {@inheritdoc}
  */
-class WebDownloadContext implements Context, GathersContexts
+class WebDownloadContext implements Context
 {
+    use UsesFlexibleContext;
     use UsesStoreContext;
 
     protected static $baseUrlRegExp = '/^((http(s|):[\/]{2}|)([a-zA-Z]+\.|)[a-zA-Z0-9]+\.[a-zA-Z]+(\:[\d]+|)|[a-zA-Z0-9]+)/';
-
-    /** @var FlexibleContext */
-    protected $flexibleContext;
-
-    /**
-     * {@inheritdoc}
-     */
-    public function gatherContexts(BeforeScenarioScope $scope)
-    {
-        $environment = $scope->getEnvironment();
-
-        if (!($environment instanceof InitializedContextEnvironment)) {
-            throw new RuntimeException(
-                'Expected Environment to be ' . InitializedContextEnvironment::class .
-                    ', but got ' . get_class($environment)
-          );
-        }
-
-        if (!$this->flexibleContext = $environment->getContext(FlexibleContext::class)) {
-            throw new RuntimeException('Failed to gather FlexibleContext');
-        }
-    }
 
     /**
      * Downloads the file references by the link and stores the content under the given key in the store.

--- a/src/Medology/Behat/ParallelWorker/Filter.php
+++ b/src/Medology/Behat/ParallelWorker/Filter.php
@@ -11,7 +11,7 @@ use InvalidArgumentException;
 use RuntimeException;
 
 /**
- * A scenario filter which filters on individual scenarios and outlines. Usefull for separating tests onto multiple
+ * A scenario filter which filters on individual scenarios and outlines. Useful for separating tests onto multiple
  * worker nodes.
  *
  * Based on the behat-partial-runner (http://github.com/m00t/behat-partial-runner) by Anton Serdyuk (m00t).

--- a/src/Medology/Behat/TypeCaster.php
+++ b/src/Medology/Behat/TypeCaster.php
@@ -49,8 +49,8 @@ trait TypeCaster
      * Casts a Quoted string to a string.
      *
      * This is helpful for when you want to write a step definition that
-     * accepts values that look like other scalar types, such as ints or
-     * bools.
+     * accepts values that look like other scalar types, such as int or
+     * bool.
      *
      * For example, if you wrote your step definition as follows:
      *

--- a/src/Medology/Behat/UsesCsvContext.php
+++ b/src/Medology/Behat/UsesCsvContext.php
@@ -1,0 +1,38 @@
+<?php namespace Medology\Behat;
+
+use Behat\Behat\Context\Environment\InitializedContextEnvironment;
+use Behat\Behat\Hook\Scope\BeforeScenarioScope;
+use RuntimeException;
+
+/**
+ * Trait that grants access to the CsvContext instance via $this->csvContext.
+ */
+trait UsesCsvContext
+{
+    /** @var CsvContext */
+    protected $csvContext;
+
+    /**
+     * Gathers the CsvContext instance and stores a reference in $this->csvContext.
+     *
+     * @param  BeforeScenarioScope $scope
+     * @throws RuntimeException    If the current environment is not initialized.
+     * @return void
+     * @BeforeScenario
+     */
+    public function gatherCsvContext(BeforeScenarioScope $scope)
+    {
+        $environment = $scope->getEnvironment();
+
+        if (!($environment instanceof InitializedContextEnvironment)) {
+            throw new RuntimeException(
+                'Expected Environment to be ' . InitializedContextEnvironment::class .
+                ', but got ' . get_class($environment)
+            );
+        }
+
+        if (!$this->csvContext = $environment->getContext(CsvContext::class)) {
+            throw new RuntimeException('Failed to gather CsvContext');
+        }
+    }
+}

--- a/src/Medology/Behat/UsesStoreContext.php
+++ b/src/Medology/Behat/UsesStoreContext.php
@@ -1,0 +1,38 @@
+<?php namespace Medology\Behat;
+
+use Behat\Behat\Context\Environment\InitializedContextEnvironment;
+use Behat\Behat\Hook\Scope\BeforeScenarioScope;
+use RuntimeException;
+
+/**
+ * Trait that grants access to the StoreContext instance via $this->storeContext.
+ */
+trait UsesStoreContext
+{
+    /** @var StoreContext */
+    protected $storeContext;
+
+    /**
+     * Gathers the StoreContext instance and stores a reference in $this->storeContext.
+     *
+     * @param  BeforeScenarioScope $scope
+     * @throws RuntimeException    If the current environment is not initialized.
+     * @return void
+     * @BeforeScenario
+     */
+    public function gatherStoreContext(BeforeScenarioScope $scope)
+    {
+        $environment = $scope->getEnvironment();
+
+        if (!($environment instanceof InitializedContextEnvironment)) {
+            throw new RuntimeException(
+                'Expected Environment to be ' . InitializedContextEnvironment::class .
+                ', but got ' . get_class($environment)
+            );
+        }
+
+        if (!$this->storeContext = $environment->getContext(StoreContext::class)) {
+            throw new RuntimeException('Failed to gather StoreContext');
+        }
+    }
+}

--- a/tests/Behat/DefaultMocks/MagicMethods.php
+++ b/tests/Behat/DefaultMocks/MagicMethods.php
@@ -26,5 +26,6 @@ class MagicMethods
 
     public function __toString()
     {
+        return '';
     }
 }

--- a/tests/Medology/Behat/ParallelWorker/FilterTest.php
+++ b/tests/Medology/Behat/ParallelWorker/FilterTest.php
@@ -19,7 +19,7 @@ class FilterTest extends FilterTestBase
         // message check
         try {
             new Filter(-10, 10);
-            $this->expectException(InvalidArgumentException::class);
+            self::setExpectedException(InvalidArgumentException::class);
         } catch (Exception $e) {
             $this->assertEquals('Received bad arguments for ($curNode, $totalNodes): (-10, 10).', $e->getMessage());
         }
@@ -29,28 +29,28 @@ class FilterTest extends FilterTestBase
          **************************/
         try {
             new Filter(-1, 1);
-            $this->expectException(InvalidArgumentException::class);
+            self::setExpectedException(InvalidArgumentException::class);
         } catch (Exception $e) {
             $this->assertTrue($e instanceof InvalidArgumentException);
         }
 
         try {
             new Filter(0, 0);
-            $this->expectException(InvalidArgumentException::class);
+            self::setExpectedException(InvalidArgumentException::class);
         } catch (Exception $e) {
             $this->assertTrue($e instanceof InvalidArgumentException);
         }
 
         try {
             new Filter(-1, -1);
-            $this->expectException(InvalidArgumentException::class);
+            self::setExpectedException(InvalidArgumentException::class);
         } catch (Exception $e) {
             $this->assertTrue($e instanceof InvalidArgumentException);
         }
 
         try {
             new Filter(2, 1);
-            $this->expectException(InvalidArgumentException::class);
+            self::setExpectedException(InvalidArgumentException::class);
         } catch (Exception $e) {
             $this->assertTrue($e instanceof InvalidArgumentException);
         }
@@ -105,12 +105,14 @@ class FilterTest extends FilterTestBase
         $this->assertEquals('Scenario#3', $scenarios[2]->getTitle());
 
         $this->assertTrue($scenarios[2] instanceof OutlineNode);
-        $this->assertTrue($scenarios[2]->hasExamples());
+        /** @var OutlineNode $outline */
+        $outline = $scenarios[2];
+        $this->assertTrue($outline->hasExamples());
         $this->assertEquals([
             ['action' => 'act#1', 'outcome' => 'out#1'],
             ['action' => 'act#2', 'outcome' => 'out#2'],
             ['action' => 'act#3', 'outcome' => 'out#3'],
-        ], $scenarios[2]->getExampleTable()->getColumnsHash());
+        ], $outline->getExampleTable()->getColumnsHash());
 
         $this->assertEquals('Scenario#3 HD Remix', $scenarios[3]->getTitle());
     }
@@ -132,11 +134,13 @@ class FilterTest extends FilterTestBase
         $this->assertEquals('Scenario#3', $scenarios[1]->getTitle());
 
         $this->assertTrue($scenarios[1] instanceof OutlineNode);
-        $this->assertTrue($scenarios[1]->hasExamples());
+        /** @var OutlineNode $outline */
+        $outline = $scenarios[1];
+        $this->assertTrue($outline->hasExamples());
         $this->assertEquals([
             ['action' => 'act#1', 'outcome' => 'out#1'],
             ['action' => 'act#3', 'outcome' => 'out#3'],
-        ], $scenarios[1]->getExampleTable()->getColumnsHash());
+        ], $outline->getExampleTable()->getColumnsHash());
 
         /*****************
          *    Node 2    *
@@ -150,10 +154,12 @@ class FilterTest extends FilterTestBase
         $this->assertEquals('Scenario#3', $scenarios[1]->getTitle());
 
         $this->assertTrue($scenarios[1] instanceof OutlineNode);
-        $this->assertTrue($scenarios[1]->hasExamples());
+        /** @var OutlineNode $outline */
+        $outline = $scenarios[1];
+        $this->assertTrue($outline->hasExamples());
         $this->assertEquals([
             ['action' => 'act#2', 'outcome' => 'out#2'],
-        ], $scenarios[1]->getExampleTable()->getColumnsHash());
+        ], $outline->getExampleTable()->getColumnsHash());
 
         $this->assertEquals('Scenario#3 HD Remix', $scenarios[2]->getTitle());
     }
@@ -175,10 +181,12 @@ class FilterTest extends FilterTestBase
         $this->assertEquals('Scenario#3', $scenarios[1]->getTitle());
 
         $this->assertTrue($scenarios[1] instanceof OutlineNode);
-        $this->assertTrue($scenarios[1]->hasExamples());
+        /** @var OutlineNode $outline */
+        $outline = $scenarios[1];
+        $this->assertTrue($outline->hasExamples());
         $this->assertEquals([
             ['action' => 'act#2', 'outcome' => 'out#2'],
-        ], $scenarios[1]->getExampleTable()->getColumnsHash());
+        ], $outline->getExampleTable()->getColumnsHash());
 
         /*****************
          *    Node 2    *
@@ -192,10 +200,12 @@ class FilterTest extends FilterTestBase
         $this->assertEquals('Scenario#3', $scenarios[1]->getTitle());
 
         $this->assertTrue($scenarios[1] instanceof OutlineNode);
-        $this->assertTrue($scenarios[1]->hasExamples());
+        /** @var OutlineNode $outline */
+        $outline = $scenarios[1];
+        $this->assertTrue($outline->hasExamples());
         $this->assertEquals([
             ['action' => 'act#3', 'outcome' => 'out#3'],
-        ], $scenarios[1]->getExampleTable()->getColumnsHash());
+        ], $outline->getExampleTable()->getColumnsHash());
 
         /*****************
          *    Node 3    *
@@ -208,10 +218,12 @@ class FilterTest extends FilterTestBase
         $this->assertEquals('Scenario#3', $scenarios[0]->getTitle());
 
         $this->assertTrue($scenarios[0] instanceof OutlineNode);
-        $this->assertTrue($scenarios[0]->hasExamples());
+        /** @var OutlineNode $outline */
+        $outline = $scenarios[0];
+        $this->assertTrue($outline->hasExamples());
         $this->assertEquals([
             ['action' => 'act#1', 'outcome' => 'out#1'],
-        ], $scenarios[0]->getExampleTable()->getColumnsHash());
+        ], $outline->getExampleTable()->getColumnsHash());
 
         $this->assertEquals('Scenario#3 HD Remix', $scenarios[1]->getTitle());
     }
@@ -233,10 +245,12 @@ class FilterTest extends FilterTestBase
         $this->assertEquals('Scenario#3', $scenarios[1]->getTitle());
 
         $this->assertTrue($scenarios[1] instanceof OutlineNode);
-        $this->assertTrue($scenarios[1]->hasExamples());
+        /** @var OutlineNode $outline */
+        $outline = $scenarios[1];
+        $this->assertTrue($outline->hasExamples());
         $this->assertEquals([
             ['action' => 'act#3', 'outcome' => 'out#3'],
-        ], $scenarios[1]->getExampleTable()->getColumnsHash());
+        ], $outline->getExampleTable()->getColumnsHash());
 
         /*****************
          *    Node 2   *
@@ -260,10 +274,12 @@ class FilterTest extends FilterTestBase
         $this->assertEquals('Scenario#3', $scenarios[0]->getTitle());
 
         $this->assertTrue($scenarios[0] instanceof OutlineNode);
-        $this->assertTrue($scenarios[0]->hasExamples());
+        /** @var OutlineNode $outline */
+        $outline = $scenarios[0];
+        $this->assertTrue($outline->hasExamples());
         $this->assertEquals([
             ['action' => 'act#1', 'outcome' => 'out#1'],
-        ], $scenarios[0]->getExampleTable()->getColumnsHash());
+        ], $outline->getExampleTable()->getColumnsHash());
 
         /*****************
          *    Node 4    *
@@ -276,9 +292,11 @@ class FilterTest extends FilterTestBase
         $this->assertEquals('Scenario#3', $scenarios[0]->getTitle());
 
         $this->assertTrue($scenarios[0] instanceof OutlineNode);
-        $this->assertTrue($scenarios[0]->hasExamples());
+        /** @var OutlineNode $outline */
+        $outline = $scenarios[0];
+        $this->assertTrue($outline->hasExamples());
         $this->assertEquals([
             ['action' => 'act#2', 'outcome' => 'out#2'],
-        ], $scenarios[0]->getExampleTable()->getColumnsHash());
+        ], $outline->getExampleTable()->getColumnsHash());
     }
 }

--- a/tests/Medology/Behat/StoreContextTest.php
+++ b/tests/Medology/Behat/StoreContextTest.php
@@ -7,7 +7,6 @@ use Medology\Behat\StoreContext;
 use PHPUnit_Framework_Error;
 use PHPUnit_Framework_TestCase;
 use stdClass;
-use TypeError;
 
 class StoreContextTest extends PHPUnit_Framework_TestCase
 {
@@ -67,6 +66,7 @@ class StoreContextTest extends PHPUnit_Framework_TestCase
 
         // test invalid argument for $string
         try {
+            /* @noinspection PhpParamsInspection intentional wrong argument type */
             $this->storeContext->injectStoredValues([]);
             $this->setExpectedException('PHPUnit_Framework_Error_Warning');
         } catch (Exception $e) {
@@ -174,7 +174,8 @@ class StoreContextTest extends PHPUnit_Framework_TestCase
         }
 
         // test function with no return
-        $badFn = function ($a) {
+        $badFn = function (/* @noinspection PhpUnusedParameterInspection */ $a) {
+            /** @noinspection PhpUnusedLocalVariableInspection */
             $a = 1;
         };
 
@@ -187,7 +188,7 @@ class StoreContextTest extends PHPUnit_Framework_TestCase
         }
 
         // test function with bad return
-        $badFn = function ($a) {
+        $badFn = function (/* @noinspection PhpUnusedParameterInspection */ $a) {
             return 'bad return';
         };
 
@@ -199,7 +200,7 @@ class StoreContextTest extends PHPUnit_Framework_TestCase
             $this->assertEquals('The $onGetFn method must return an object or an array!', $e->getMessage());
         }
 
-        $badFn = function ($a) {
+        $badFn = function (/* @noinspection PhpUnusedParameterInspection */ $a) {
             return function () {
             };
         };
@@ -221,7 +222,7 @@ class StoreContextTest extends PHPUnit_Framework_TestCase
             $this->storeContext->injectStoredValues('(the test_property_1 of the testObj)', $goodFn)
         );
 
-        // test accessing property after unsetting with callback
+        // test accessing property after un-setting with callback
         $goodFn = function ($thing) {
             unset($thing->test_property_1);
 
@@ -298,10 +299,10 @@ class StoreContextTest extends PHPUnit_Framework_TestCase
         $wrongReturnTypes = [
             function ($a, $b) {
             },
-            function ($a, $b) {
+            function (/* @noinspection PhpUnusedParameterInspection */ $a, $b) {
                 return '';
             },
-            function ($a, $b) {
+            function (/* @noinspection PhpUnusedParameterInspection */ $a, $b) {
                 return function () {
                 };
             },
@@ -321,7 +322,7 @@ class StoreContextTest extends PHPUnit_Framework_TestCase
             $this->storeContext->injectStoredValues(
                 '(the test_property_1 of the testObj)',
                 null,
-                function ($a, $b) {
+                function (/* @noinspection PhpUnusedParameterInspection */ $a, $b) {
                     return false;
                 }
             );

--- a/web/button-disabled.html
+++ b/web/button-disabled.html
@@ -8,7 +8,7 @@
        document.getElementById("disabled-button").removeAttribute("disabled");
    }
    function disableEnabledButton() {
-       document.getElementById("enabled-button").setAttribute("disabled", null);
+       document.getElementById("enabled-button").setAttribute("disabled", '');
    }
   </script>
 </head>

--- a/web/image-load-test.html
+++ b/web/image-load-test.html
@@ -16,7 +16,7 @@
   <h1>Valid Image Link</h1>
   <img src="img/medology.png" id="valid-image" alt="Valid Image" />
   <h1>Invalid (Broken) Image</h1>
-  <img src="img/doesnotexist.png" id="invalid-image" alt="Invalid Image" />
+  <img src="img/doesNotExist.png" id="invalid-image" alt="Invalid Image" />
 </body>
 
 </html>

--- a/web/page-load-delay.html
+++ b/web/page-load-delay.html
@@ -11,7 +11,7 @@
 
           // delay the click for 2 seconds
           setTimeout(function() {
-            location = $("#sml_delay").attr('href');
+            window.location = $("#sml_delay").attr('href');
           }, 2000);
 
           return false;
@@ -23,7 +23,7 @@
 
           // delay the click for 7 seconds
           setTimeout(function() {
-            location = $("#big_delay").attr('href');
+              window.location = $("#big_delay").attr('href');
           }, 7000);
 
           return false;


### PR DESCRIPTION
The first three commits reduce the overall code of the project and remove duplication.

The last six commits add traits that do not necessarily reduce duplication for **this** project but will allow users of FlexibleMink to more easily gain access to the individual trait instances without having to write multiple `gathersContexts()` methods themselves.

Please see commits for details.