### PR TITLE
Fix PHP image cannot go over Github API rate limit

### DIFF
--- a/bin/lib/exitCheck.sh
+++ b/bin/lib/exitCheck.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+# Checks the exit code of the previous command and bails if it's not zero
+exitCheck() {
+  if [ $1 != 0 ]; then
+    echo "Got exit code $1, quitting."
+    exit $1
+  fi
+}

--- a/bin/php
+++ b/bin/php
@@ -1,7 +1,18 @@
 #!/bin/bash +x
 
-docker run --rm -it --env-file "$(pwd)"/docker/.env \
-    -v "$(pwd)":/app -w /app \
-	--link web:dockermachine.local \
-	--net flexiblemink_default \
-	php:5.6-cli php "$@"
+ROOT="$( cd "$( dirname "${BASH_SOURCE[0]}" )"/.. && pwd )"
+
+. "${ROOT}"/docker/lib/docker_host_user_id.sh
+
+docker run \
+    --env-file "$(pwd)"/docker/.env \
+    --link web:dockermachine.local \
+    --net flexiblemink_default \
+    --rm \
+    -e LOCAL_USER_ID=$DOCKER_HOST_USER_ID \
+    -i \
+    -t \
+    -v "$(pwd)":/app \
+    -v ~/.composer:/home/user/.composer \
+    -w /app \
+    chekote/php:5.6.31-laravel php "$@"

--- a/docker/lib/docker_host_user_id.sh
+++ b/docker/lib/docker_host_user_id.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+# Determines the UID of the user running the Docker containers.
+
+if [ `uname` == 'Darwin' ]; then
+  # We're on Mac OS  X. We're Virtualized using xhyve, and have a UID of 1000.
+  export DOCKER_HOST_USER_ID=1000
+else
+  # We're on Linux. There's no virtualization, so we use our own UID.
+  export DOCKER_HOST_USER_ID=`id -u`
+fi


### PR DESCRIPTION
Problem:
When hitting the Github API rate limit, the PHP image is asking for an auth token.

Cause:
The PHP image is not mounting the hosts ~/.composer directory. So even if the Docker host has an auth token, it is not used.

Fix:
I updated the PHP image to mount the ~/.composer directory. The new image also brings in some other quality of life features, such as the ability to ctrl-c out of the container, and run the script on both Linux and Mac.