### PR TITLE
Update Composer bin to 1.5.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 .idea/
-
+bin/composer
 /vendor/
 docker/.env

--- a/bin/composer
+++ b/bin/composer
@@ -1,3 +1,0 @@
-#!/bin/bash +x
-
-docker run --rm --env-file "$(pwd)"/docker/.env -v "$(pwd)":/data -w /data composer/composer:1.2 $@

--- a/bin/init/install_composer.sh
+++ b/bin/init/install_composer.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+
+ROOT="$( cd "$( dirname "${BASH_SOURCE[0]}" )/../.." && pwd )"
+
+. "$ROOT"/bin/lib/exitCheck.sh
+
+EXPECTED_VERSION=1.5.2
+
+# Check for existing installation
+if [ -e "$ROOT"/bin/composer ]; then
+    echo "Checking Composer version..."
+    FOUND_VERSION=`( \
+        cd "$ROOT" && \
+        ./bin/composer --version | \
+        tail -1 | \
+        awk '{print $3}' | \
+        "$ROOT"/bin/linux-sed -r "s/\x1B\[([0-9]{1,2}(;[0-9]{1,2})?)?[mGK]//g" \
+    )`
+
+    # Check version of installed composer
+    if [ "$FOUND_VERSION" == "$EXPECTED_VERSION" ]; then
+        # Version is as expected. We're done.
+        echo "Composer ${EXPECTED_VERSION} already installed."
+        exit 0
+    else
+        # Version does not match. Remove it.
+        echo "Removing Composer version ${FOUND_VERSION}..."
+        rm "$ROOT"/bin/composer
+        exitCheck $?
+    fi
+fi
+
+# Install composer
+echo "Installing Composer ${EXPECTED_VERSION}..."
+curl -L https://getcomposer.org/download/${EXPECTED_VERSION}/composer.phar > "$ROOT"/bin/composer
+exitCheck $?
+
+# Fix permissions
+echo "Setting composer permissions..."
+chmod 755 "$ROOT"/bin/composer
+exitCheck $?
+
+# Ensure ~/.composer exists for the Docker container to mount
+echo "Initializing ~/.composer directory..."
+if [ ! -d ~/.composer ]; then
+    mkdir ~/.composer
+    exitCheck $?
+fi
+
+echo "Composer v${EXPECTED_VERSION} installation complete."

--- a/bin/init_project
+++ b/bin/init_project
@@ -1,5 +1,14 @@
 #!/bin/bash +x
 
+ROOT="$( cd "$( dirname "${BASH_SOURCE[0]}" )"/.. && pwd )"
+
+. "$ROOT"/bin/lib/exitCheck.sh
+
+# install composer
+echo "Installing composer..."
+bin/init/install_composer.sh
+exitCheck $?
+
 # install composer dependancies
 echo "Installing composer dependancies..."
 bin/composer install


### PR DESCRIPTION
Problem:
The composer script is actually an alias for a docker image that contains composer. Although this works, it is not necessary as we already have a PHP image in the project.

Solution:
In addition to updated the composer version, I modified the project so that the composer binary is not in version control. Instead it is installed via a command in init_project. The composer file that is installed is the normal phar, and is simply executed against the bin/php Docker image since the `#!/usr/bin/env php` at the beginning of the composer file will resolve to `./bin/php` if `./bin` is sufficiently high in the users PATH list (which it should be).