### PR TITLE
Fixing issue with nested table check

### DIFF
--- a/features/TableContext.feature
+++ b/features/TableContext.feature
@@ -59,3 +59,8 @@ Feature: Table Context
      And the table "table-with-select" should have the following values:
       | Name    | Zhang |
       | Country | China |
+
+  Scenario: Developer can Test a table with a nested table within it
+    Then there should be a table on the page with the following information:
+      | Test Column                             |
+      | Testing Column with Hidden Nested Table |

--- a/src/Behat/FlexibleMink/Context/TableContext.php
+++ b/src/Behat/FlexibleMink/Context/TableContext.php
@@ -415,7 +415,7 @@ trait TableContext
             $domTables = $page->findAll('css', 'table');
             foreach ($domTables as $domTable) {
                 /** @var NodeElement[] $domRows */
-                $domRows = $domTable->findAll('css', 'tr');
+                $domRows = $domTable->findAll('xpath', '/thead/tr|tbody/tr');
 
                 if (count($domRows) != count($table)) {
                     // This table doesn't have enough rows to match us.
@@ -426,7 +426,7 @@ trait TableContext
                     $domRow = $domRows[$rowNum];
 
                     /** @var NodeElement[] $domCells */
-                    $domCells = $domRow->findAll('css', 'th, td');
+                    $domCells = $domRow->findAll('xpath', '/th|td');
 
                     if (count($domCells) != count($row)) {
                         // This table doesn't have enough columns to match us.

--- a/web/table.html
+++ b/web/table.html
@@ -171,6 +171,33 @@
       </tr>
     </tbody>
   </table>
+
+<table id="table-with-nested-table">
+  <thead>
+    <tr>
+      <th>Test Column</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>
+        Testing Column with Hidden Nested Table
+        <table style="visibility: hidden;">
+          <thead>
+            <tr>
+              <th>Random Header</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>Random Content</td>
+            </tr>
+          </tbody>
+        </table>
+      </td>
+    </tr>
+  </tbody>
+</table>
 </body>
 
 </html>


### PR DESCRIPTION
When using the `TableContext::assertTableWithStructureExists()` method I noticed that I kept gettin an error whenever testing a table that had another table nested in it.

This was due to the method attempting to retrieve all rows and columns within a specified table instead of only checking for the most top level ones.