### PR TITLE
Added functionality for deep JSON object injection (#131)

### DIFF
--- a/features/StoreContext.feature
+++ b/features/StoreContext.feature
@@ -57,3 +57,20 @@ Feature: Store Context
      When I assert that the "body" of the "Slogan" should contain "candy"
      Then the assertion should throw an Exception
       And the assertion should fail with the message "Expected the 'body' of the 'Slogan' to contain 'candy', but found 'Eat more cake' instead"
+
+  Scenario: Can Assert The Deep Property of Thing Contains Value
+    Given the following complex object is stored as "Family":
+      """
+      {
+        "name": "Mary",
+        "parent": {
+          "name": "Sam",
+          "parent": {
+            "name": "Fred"
+          }
+        }
+      }
+      """
+    Then the "name" of the "Family" should contain "Mary"
+     And the deep property "(the parent->name of the Family)" should contain "Sam"
+     And the deep property "(the parent->parent->name of the Family)" should contain "Fred"

--- a/features/bootstrap/FeatureContext.php
+++ b/features/bootstrap/FeatureContext.php
@@ -166,4 +166,17 @@ JS
 
         return true;
     }
+
+    /**
+     * Places a complex object with the given structure into the store.
+     *
+     * @Given the following complex object is stored as :key:
+     * @param string       $key     The key to put the object into the store under.
+     * @param PyStringNode $rawJson The JSON of the object to create.
+     */
+    public function putComplexStoreStep($key, PyStringNode $rawJson)
+    {
+        $complexObject = json_decode($rawJson->getRaw());
+        $this->put($complexObject, $key);
+    }
 }

--- a/src/Behat/FlexibleMink/Context/StoreContext.php
+++ b/src/Behat/FlexibleMink/Context/StoreContext.php
@@ -150,16 +150,36 @@ trait StoreContext
                 throw new Exception('The $onGetFn method must return an object or an array!');
             }
 
-            $hasValueResult = $hasValue($thing, $thingProperty);
-            if (!is_bool($hasValueResult)) {
-                throw new Exception('$hasValue lambda must return a boolean!');
-            }
+            $replaceValue = function ($match, $thing, $thingProperty) use ($string, $thingName, $hasValue) {
+                $hasValueResult = $hasValue($thing, $thingProperty);
+                if (!is_bool($hasValueResult)) {
+                    throw new Exception('$hasValue lambda must return a boolean!');
+                }
 
-            if (!$hasValueResult) {
-                throw new Exception("$thingName does not have a $thingProperty property");
-            }
+                if (!$hasValueResult) {
+                    throw new Exception("$thingName does not have a $thingProperty property");
+                }
 
-            $string = str_replace($match, $thing->$thingProperty, $string);
+                return str_replace($match, $thing->$thingProperty, $string);
+            };
+
+            if (strpos($thingProperty, '->') !== false) {
+                $pieces = explode('->', $thingProperty);
+                $deepThing = $thing;
+                $lastPieceIndex = count($pieces) - 1;
+                for ($a = 0; $a < $lastPieceIndex; ++$a) {
+                    $piece = $pieces[$a];
+                    if (!property_exists($deepThing, $piece)) {
+                        throw new Exception("$thingName does not have a deep property called '$piece'");
+                    }
+
+                    $deepThing = $deepThing->$piece;
+                }
+
+                $string = $replaceValue($match, $deepThing, $pieces[$lastPieceIndex]);
+            } else {
+                $string = $replaceValue($match, $thing, $thingProperty);
+            }
         }
 
         return $string;
@@ -197,6 +217,24 @@ trait StoreContext
         $expected = $this->injectStoredValues($expected);
 
         $actual = $this->getThingProperty($thing, $property);
+        if (strpos($actual, $expected) === false) {
+            throw new Exception("Expected the '$property' of the '$thing' to contain '$expected', but found '$actual' instead");
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @Then the deep property :property should contain :expected
+     */
+    public function assertComplexThingPropertyContains($property, $expected)
+    {
+        $matches = [];
+        preg_match('/of the (.+)\)/', $property, $matches);
+        $thing = $matches[1];
+
+        $actual = $this->injectStoredValues($property);
+
         if (strpos($actual, $expected) === false) {
             throw new Exception("Expected the '$property' of the '$thing' to contain '$expected', but found '$actual' instead");
         }


### PR DESCRIPTION
This feature allows an attribute from a JSON object of an indefinite depth to be parsed by FlexibleMink's `injectStoredValues()` system, so that the following Behat feature lines will parse successfully:

```
    When the affiliate sends a GET request to "/api/v1/account/(the account->accounts_id of the response)/orders"
    Then the deep property "(the parent->parent->name of the Family)" should contain "Mary"
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/medology/flexiblemink/132)
<!-- Reviewable:end -->
