### PR TITLE
Fixing issue with asserting field exists (#135)

### DIFF
--- a/features/FlexibleContext/assertFieldExists.feature
+++ b/features/FlexibleContext/assertFieldExists.feature
@@ -18,7 +18,7 @@ Feature:  Assert Fields exists
     When I assert that I should see the following fields:
        | Utopia |
     Then the assertion should throw an ExpectationException
-     And the assertion should fail with the message "No input label 'Utopia' found"
+     And the assertion should fail with the message "No visible input found for 'Utopia'"
 
   Scenario: Assertion fails reliably if checkbox element is not visible
     When I assert that I should see the following fields:
@@ -30,7 +30,7 @@ Feature:  Assert Fields exists
     When I assert that I should see the following fields:
        | Sushi |
     Then the assertion should throw an ExpectationException
-     And the assertion should fail with the message "No input label 'Sushi' found"
+     And the assertion should fail with the message "No visible input found for 'Sushi'"
 
   Scenario: Developer Can Test for option with varying input/label setup
     Then I should see the following fields:
@@ -42,3 +42,10 @@ Feature:  Assert Fields exists
      And I check "Hot Dog"
      And I press "Submit Favorites"
     Then I should see "Selected: Pizza, Hamburger, Hot Dog"
+
+  Scenario: Fields With Duplicate Label Names Should Modify the First Visible
+    Then I should see the following fields:
+       | Text Input: |
+    When I fill in "Text Input:" with "test"
+     And I press "Submit Favorites"
+    Then I should see "invisibleInput: , visibleInput: test"

--- a/src/Behat/FlexibleMink/PseudoInterface/FlexibleContextInterface.php
+++ b/src/Behat/FlexibleMink/PseudoInterface/FlexibleContextInterface.php
@@ -205,6 +205,16 @@ trait FlexibleContextInterface
     abstract public function assertFieldExists($fieldName, TraversableElement $context = null);
 
     /**
+     * Gets all the inputs that have the label name specified within the context specified.
+     *
+     * @param string             $labelName The label text used to find the inputs for.
+     * @param TraversableElement $context   The context to search in.
+     *
+     * @return NodeElement[]
+     */
+    abstract public function getInputsByLabel($labelName, TraversableElement $context);
+
+    /**
      * Checks that the page not contain a visible input field.
      *
      * @param  string               $fieldName The name of the input field.

--- a/web/assert-field-exists.html
+++ b/web/assert-field-exists.html
@@ -34,18 +34,32 @@
         <input type="checkbox" name="favoriteFood" value="Chocolate" id="Chocolate">
             <label for="Chocolate">Chocolate</label>
         <label class="hidden"><input type="checkbox" name="favoriteFood" value="Kale Salad"> Kale Salad</label>
+        <label for="invisibleInput">Text Input:</label><input class="hidden" name="invisibleInput" type="text">
+        <label for="visibleInput">Text Input:</label><input name="visibleInput" type="text">
         <button type="submit">Submit Favorites</button>
         <div id="foodSelected"></div>
+        <div id="textEntered"></div>
     </form>
 </section>
 <script>
     function foodSubmit() {
         var checkedElements = document.querySelectorAll('input[name="favoriteFood"]:checked');
+        var textElements = document.querySelectorAll('input[type="text"]');
+
         var foods = [];
+        var text = [];
+
         for (var i = 0; i < checkedElements.length; i++) {
             foods.push(checkedElements[i].value);
         }
+
+        for (var i = 0; i < textElements.length; i++) {
+            console.log();
+            text.push(textElements[i].getAttribute('name') + ': ' + textElements[i].value);
+        }
+
         document.getElementById('foodSelected').innerText = 'Selected: ' + foods.join(', ');
+        document.getElementById('textEntered').innerText = text.join(', ');
     }
 </script>
 </body>


### PR DESCRIPTION
* Adding a test that asserts that whenever multiple fields with the same label name exist,
the first visible is used as opposed to just the first one regardless of visibility status.

* At the moment, it looks like `FlexibleContext::assertFieldExists()` attempts to find all fields that are named whichever field name is specified and returns the first
visible one it finds when it exists.  If none is found through this way, it attempts to try to find fields by using label names as sort of a last resort.

When attempting to find items by the last resort method, `$context->find()` is used instead of `findAll` so it behaves differently in the last resort method compared
to trying to find inputs by their name.

Because of this one can get into an issue where an item can have the same label name for multiple items, but only the first item found would be checked and returned.

* fix some failing tests