### PR TITLE
The `getInputsByLabel` method that was modified before, was attemptin…

### DIFF
--- a/src/Medology/Behat/Mink/FlexibleContext.php
+++ b/src/Medology/Behat/Mink/FlexibleContext.php
@@ -348,11 +348,13 @@ class FlexibleContext extends MinkContext
             $inputName = $label->getAttribute('for');
 
             foreach ($context->findAll('named', ['field', $inputName]) as $element) {
-                $found[$inputName] = $element;
+                if (!in_array($element, $found)) {
+                    array_push($found, $element);
+                }
             }
         }
 
-        return array_values($found);
+        return $found;
     }
 
     /**


### PR DESCRIPTION
At the moment `getInputsByLabel()` attempts to not return duplicate values for usage by relying on unique names which isn't always the case on forms.  Replaced this instead with an `in_array` check when appending to the `$found` array.
