### PR TITLE
small change to `getInputsByLabel`

### DIFF
--- a/src/Behat/FlexibleMink/Context/FlexibleContext.php
+++ b/src/Behat/FlexibleMink/Context/FlexibleContext.php
@@ -376,11 +376,13 @@ class FlexibleContext extends MinkContext
             $inputName = $label->getAttribute('for');
 
             foreach ($context->findAll('named', ['field', $inputName]) as $element) {
-                $found[$inputName] = $element;
+                if (!in_array($element, $found)) {
+                    array_push($found, $element);
+                }
             }
         }
 
-        return array_values($found);
+        return $found;
     }
 
     /**


### PR DESCRIPTION
At the moment `getInputsByLabel()` attempts to not return duplicate values for usage by relying on unique names which isn't always the case on forms.  Replaced this instead with an `in_array` check when appending to the `$found` array.
