### PR TITLE
Spin assertSelectContainsExactOptions()

### DIFF
--- a/features/FlexibleContext/assertFieldExists.feature
+++ b/features/FlexibleContext/assertFieldExists.feature
@@ -18,7 +18,7 @@ Feature:  Assert Fields exists
     When I assert that I should see the following fields:
        | Utopia |
     Then the assertion should throw an ExpectationException
-     And the assertion should fail with the message "No input label 'Utopia' found"
+     And the assertion should fail with the message "No visible input found for 'Utopia'"
 
   Scenario: Assertion fails reliably if checkbox element is not visible
     When I assert that I should see the following fields:
@@ -30,7 +30,7 @@ Feature:  Assert Fields exists
     When I assert that I should see the following fields:
        | Sushi |
     Then the assertion should throw an ExpectationException
-     And the assertion should fail with the message "No input label 'Sushi' found"
+     And the assertion should fail with the message "No visible input found for 'Sushi'"
 
   Scenario: Developer Can Test for option with varying input/label setup
     Then I should see the following fields:
@@ -42,3 +42,10 @@ Feature:  Assert Fields exists
      And I check "Hot Dog"
      And I press "Submit Favorites"
     Then I should see "Selected: Pizza, Hamburger, Hot Dog"
+
+  Scenario: Fields With Duplicate Label Names Should Modify the First Visible
+    Then I should see the following fields:
+       | Text Input: |
+    When I fill in "Text Input:" with "test"
+     And I press "Submit Favorites"
+    Then I should see "invisibleInput: , visibleInput: test"

--- a/features/FlexibleContext/assertOptionInSelect.feature
+++ b/features/FlexibleContext/assertOptionInSelect.feature
@@ -64,3 +64,13 @@ Feature:  Assert Option in Select
      | Texas | Ohio |
     Then the assertion should throw an InvalidArgumentException
      And the assertion should fail with the message "Arguments must be a single-column list of items"
+
+  Scenario: Assertion passes when select eventually has options
+    When I press "Update select with delay"
+    Then the "Country" select should only have the following options:
+      | US          |
+      | China       |
+      | Canada      |
+      | Australia   |
+      | New Zealand |
+      | Japan       |

--- a/src/Behat/FlexibleMink/Context/FlexibleContext.php
+++ b/src/Behat/FlexibleMink/Context/FlexibleContext.php
@@ -488,44 +488,46 @@ class FlexibleContext extends MinkContext
         }
 
         $expectedOptTexts = array_map([$this, 'injectStoredValues'], $tableNode->getColumn(0));
-
         $select = $this->fixStepArgument($select);
         $select = $this->injectStoredValues($select);
-        $selectField = $this->assertFieldExists($select);
-        $actualOpts = $selectField->findAll('xpath', '//option');
 
-        if (count($actualOpts) == 0) {
-            throw new ExpectationException('No option found in the select', $this->getSession());
-        }
+        $this->waitFor(function() use ($expectedOptTexts, $select) {
+            $selectField = $this->assertFieldExists($select);
+            $actualOpts = $selectField->findAll('xpath', '//option');
 
-        $actualOptTexts = array_map(function ($actualOpt) {
-            /* @var NodeElement $actualOpt */
-            return $actualOpt->getText();
-        }, $actualOpts);
+            if (count($actualOpts) == 0) {
+                throw new ExpectationException('No option found in the select', $this->getSession());
+            }
 
-        if (count($actualOptTexts) > count($expectedOptTexts)) {
-            throw new ExpectationException('Select has more option then expected', $this->getSession());
-        }
+            $actualOptTexts = array_map(function ($actualOpt) {
+                /* @var NodeElement $actualOpt */
+                return $actualOpt->getText();
+            }, $actualOpts);
 
-        if (count($actualOptTexts) < count($expectedOptTexts)) {
-            throw new ExpectationException('Select has less option then expected', $this->getSession());
-        }
+            if (count($actualOptTexts) > count($expectedOptTexts)) {
+                throw new ExpectationException('Select has more option then expected', $this->getSession());
+            }
 
-        if ($actualOptTexts != $expectedOptTexts) {
-            $intersect = array_intersect($actualOptTexts, $expectedOptTexts);
+            if (count($actualOptTexts) < count($expectedOptTexts)) {
+                throw new ExpectationException('Select has less option then expected', $this->getSession());
+            }
 
-            if (count($intersect) < count($expectedOptTexts)) {
+            if ($actualOptTexts != $expectedOptTexts) {
+                $intersect = array_intersect($actualOptTexts, $expectedOptTexts);
+
+                if (count($intersect) < count($expectedOptTexts)) {
+                    throw new ExpectationException(
+                        'Expecting ' . count($expectedOptTexts) . ' matching option(s), found ' . count($intersect),
+                        $this->getSession()
+                    );
+                }
+
                 throw new ExpectationException(
-                    'Expecting ' . count($expectedOptTexts) . ' matching option(s), found ' . count($intersect),
+                    'Options in select match expected but not in expected order',
                     $this->getSession()
                 );
             }
-
-            throw new ExpectationException(
-                'Options in select match expected but not in expected order',
-                $this->getSession()
-            );
-        }
+        });
     }
 
     /**

--- a/src/Behat/FlexibleMink/Context/FlexibleContext.php
+++ b/src/Behat/FlexibleMink/Context/FlexibleContext.php
@@ -376,11 +376,13 @@ class FlexibleContext extends MinkContext
             $inputName = $label->getAttribute('for');
 
             foreach ($context->findAll('named', ['field', $inputName]) as $element) {
-                $found[$inputName] = $element;
+                if (!in_array($element, $found)) {
+                    array_push($found, $element);
+                }
             }
         }
 
-        return array_values($found);
+        return $found;
     }
 
     /**

--- a/src/Behat/FlexibleMink/Context/StoreContext.php
+++ b/src/Behat/FlexibleMink/Context/StoreContext.php
@@ -102,6 +102,14 @@ trait StoreContext
     /**
      * {@inheritdoc}
      */
+    public function all($key)
+    {
+        return isset($this->registry[$key]) ? $this->registry[$key] : [];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function getThingProperty($key, $property, $nth = null)
     {
         $thing = $this->assertIsStored($key, $nth);

--- a/src/Behat/FlexibleMink/Context/TableContext.php
+++ b/src/Behat/FlexibleMink/Context/TableContext.php
@@ -50,15 +50,9 @@ trait TableContext
     }
 
     /**
-     * This method will retrieve a table by its name. If the table is stored in the key store, that will be used,
-     * otherwise a fresh parse will be done against the table's HTML. Setting {@param $forceFresh} to true will
-     * ignore the key store and build the table from HTML.
-     *
-     * @param  string $name       The name of the table to be used in an xpath query
-     * @param  bool   $forceFresh Setting to true will rebuild the table from HTML and not use the store
-     * @return array  An array containing parsed rows and cells as returned form $this->buildTableFromHtml
+     * {@inheritdoc}
      */
-    protected function getTableFromName($name, $forceFresh = false)
+    public function getTableFromName($name, $forceFresh = false)
     {
         // retrieve table from the store if it exists there
         if ($this->isStored($name) && !$forceFresh) {

--- a/src/Behat/FlexibleMink/PseudoInterface/FlexibleContextInterface.php
+++ b/src/Behat/FlexibleMink/PseudoInterface/FlexibleContextInterface.php
@@ -205,6 +205,16 @@ trait FlexibleContextInterface
     abstract public function assertFieldExists($fieldName, TraversableElement $context = null);
 
     /**
+     * Gets all the inputs that have the label name specified within the context specified.
+     *
+     * @param string             $labelName The label text used to find the inputs for.
+     * @param TraversableElement $context   The context to search in.
+     *
+     * @return NodeElement[]
+     */
+    abstract public function getInputsByLabel($labelName, TraversableElement $context);
+
+    /**
      * Checks that the page not contain a visible input field.
      *
      * @param  string               $fieldName The name of the input field.

--- a/src/Behat/FlexibleMink/PseudoInterface/StoreContextInterface.php
+++ b/src/Behat/FlexibleMink/PseudoInterface/StoreContextInterface.php
@@ -39,6 +39,14 @@ trait StoreContextInterface
     abstract public function get($key, $nth = null);
 
     /**
+     * Retrieves all the things stored under the specified key in the registry.
+     *
+     * @param  string $key The key to retrieve the things for.
+     * @return array  the things that were retrieved.
+     */
+    abstract public function all($key);
+
+    /**
      * Gets the value of a property from an object of the store.
      *
      * @param  string    $key      The key to retrieve the object for.

--- a/src/Behat/FlexibleMink/PseudoInterface/TableContextInterface.php
+++ b/src/Behat/FlexibleMink/PseudoInterface/TableContextInterface.php
@@ -92,4 +92,15 @@ trait TableContextInterface
      * @throws ExpectationException If the values are not found in the table.
      */
     abstract public function assertTableShouldHaveTheFollowingValues($name, TableNode $tableNode);
+
+    /**
+     * This method will retrieve a table by its name. If the table is stored in the key store, that will be used,
+     * otherwise a fresh parse will be done against the table's HTML. Setting $forceFresh to true will ignore
+     * the key store and build the table from HTML.
+     *
+     * @param  string $name       The name of the table to be used in an xpath query
+     * @param  bool   $forceFresh Setting to true will rebuild the table from HTML and not use the store
+     * @return array  An array containing parsed rows and cells as returned form $this->buildTableFromHtml
+     */
+    abstract public function getTableFromName($name, $forceFresh = false);
 }

--- a/web/assert-field-exists.html
+++ b/web/assert-field-exists.html
@@ -34,18 +34,32 @@
         <input type="checkbox" name="favoriteFood" value="Chocolate" id="Chocolate">
             <label for="Chocolate">Chocolate</label>
         <label class="hidden"><input type="checkbox" name="favoriteFood" value="Kale Salad"> Kale Salad</label>
+        <label for="invisibleInput">Text Input:</label><input class="hidden" name="invisibleInput" type="text">
+        <label for="visibleInput">Text Input:</label><input name="visibleInput" type="text">
         <button type="submit">Submit Favorites</button>
         <div id="foodSelected"></div>
+        <div id="textEntered"></div>
     </form>
 </section>
 <script>
     function foodSubmit() {
         var checkedElements = document.querySelectorAll('input[name="favoriteFood"]:checked');
+        var textElements = document.querySelectorAll('input[type="text"]');
+
         var foods = [];
+        var text = [];
+
         for (var i = 0; i < checkedElements.length; i++) {
             foods.push(checkedElements[i].value);
         }
+
+        for (var i = 0; i < textElements.length; i++) {
+            console.log();
+            text.push(textElements[i].getAttribute('name') + ': ' + textElements[i].value);
+        }
+
         document.getElementById('foodSelected').innerText = 'Selected: ' + foods.join(', ');
+        document.getElementById('textEntered').innerText = text.join(', ');
     }
 </script>
 </body>

--- a/web/select-option.html
+++ b/web/select-option.html
@@ -17,5 +17,20 @@
         <select id="state">
         </select>
     </form>
+    <button onclick="updateSelectWithDelay()">Update select with delay</button>
+<script>
+    function updateSelectWithDelay() {
+        setTimeout(function() {
+            let select = document.getElementById('country');
+
+            ['Australia', 'New Zealand', 'Japan'].forEach(function (value) {
+                let option = document.createElement('option');
+                option.value = value;
+                option.text = value;
+                select.add(option);
+            });
+        }, 2000);
+    }
+</script>
 </body>
 </html>


### PR DESCRIPTION
Problem:
I need to be able to test for options in a select that are added via an asynchronous process. The method currently fails immediately if the options are not present.

Fix:
I modified the method to use a waitFor()