### PR TITLE
Spin assertSelectContainsExactOptions()

### DIFF
--- a/features/FlexibleContext/assertOptionInSelect.feature
+++ b/features/FlexibleContext/assertOptionInSelect.feature
@@ -64,3 +64,13 @@ Feature:  Assert Option in Select
      | Texas | Ohio |
     Then the assertion should throw an InvalidArgumentException
      And the assertion should fail with the message "Arguments must be a single-column list of items"
+
+  Scenario: Assertion passes when select eventually has options
+    When I press "Update select with delay"
+    Then the "Country" select should only have the following options:
+      | US          |
+      | China       |
+      | Canada      |
+      | Australia   |
+      | New Zealand |
+      | Japan       |

--- a/web/select-option.html
+++ b/web/select-option.html
@@ -17,5 +17,20 @@
         <select id="state">
         </select>
     </form>
+    <button onclick="updateSelectWithDelay()">Update select with delay</button>
+<script>
+    function updateSelectWithDelay() {
+        setTimeout(function() {
+            let select = document.getElementById('country');
+
+            ['Australia', 'New Zealand', 'Japan'].forEach(function (value) {
+                let option = document.createElement('option');
+                option.value = value;
+                option.text = value;
+                select.add(option);
+            });
+        }, 2000);
+    }
+</script>
 </body>
 </html>


### PR DESCRIPTION
Problem:
I need to be able to test for options in a select that are added via an asynchronous process. The method currently fails immediately if the options are not present.

Fix:
I modified the method to use a waitFor()