### PR TITLE
Spin assertSelectContainsExactOptions()

### DIFF
--- a/features/FlexibleContext/assertOptionInSelect.feature
+++ b/features/FlexibleContext/assertOptionInSelect.feature
@@ -64,3 +64,13 @@ Feature:  Assert Option in Select
      | Texas | Ohio |
     Then the assertion should throw an InvalidArgumentException
      And the assertion should fail with the message "Arguments must be a single-column list of items"
+
+  Scenario: Assertion passes when select eventually has options
+    When I press "Update select with delay"
+    Then the "Country" select should only have the following options:
+      | US          |
+      | China       |
+      | Canada      |
+      | Australia   |
+      | New Zealand |
+      | Japan       |

--- a/src/Medology/Behat/Mink/FlexibleContext.php
+++ b/src/Medology/Behat/Mink/FlexibleContext.php
@@ -12,6 +12,7 @@ use Behat\Mink\Exception\ExpectationException;
 use Behat\Mink\Exception\ResponseTextException;
 use Behat\Mink\Exception\UnsupportedDriverActionException;
 use Behat\MinkExtension\Context\MinkContext;
+use Exception;
 use InvalidArgumentException;
 use Medology\Behat\StoreContext;
 use Medology\Behat\TypeCaster;
@@ -469,6 +470,7 @@ class FlexibleContext extends MinkContext
      * @Then   /^the "(?P<select>[^"]*)" select should only have the following option(?:|s):$/
      * @param  string                   $select    The name of the select
      * @param  TableNode                $tableNode The text of the options.
+     * @throws Exception                If the string references something that does not exist in the store.
      * @throws ExpectationException     When there is no option in the select.
      * @throws ExpectationException     When the option(s) in the select not match the option(s) listed.
      * @throws InvalidArgumentException When no expected options listed in the test step.
@@ -479,9 +481,9 @@ class FlexibleContext extends MinkContext
             throw new InvalidArgumentException('Arguments must be a single-column list of items');
         }
 
-        $expectedOptTexts = array_map([$this, 'injectStoredValues'], $tableNode->getColumn(0));
+        $expectedOptTexts = array_map([$this->storeContext, 'injectStoredValues'], $tableNode->getColumn(0));
         $select = $this->fixStepArgument($select);
-        $select = $this->injectStoredValues($select);
+        $select = $this->storeContext->injectStoredValues($select);
 
         $this->waitFor(function () use ($expectedOptTexts, $select) {
             $selectField = $this->assertFieldExists($select);

--- a/src/Medology/Behat/Mink/FlexibleContext.php
+++ b/src/Medology/Behat/Mink/FlexibleContext.php
@@ -479,45 +479,47 @@ class FlexibleContext extends MinkContext
             throw new InvalidArgumentException('Arguments must be a single-column list of items');
         }
 
-        $expectedOptTexts = array_map([$this->storeContext, 'injectStoredValues'], $tableNode->getColumn(0));
-
+        $expectedOptTexts = array_map([$this, 'injectStoredValues'], $tableNode->getColumn(0));
         $select = $this->fixStepArgument($select);
-        $select = $this->storeContext->injectStoredValues($select);
-        $selectField = $this->assertFieldExists($select);
-        $actualOpts = $selectField->findAll('xpath', '//option');
+        $select = $this->injectStoredValues($select);
 
-        if (count($actualOpts) == 0) {
-            throw new ExpectationException('No option found in the select', $this->getSession());
-        }
+        $this->waitFor(function () use ($expectedOptTexts, $select) {
+            $selectField = $this->assertFieldExists($select);
+            $actualOpts = $selectField->findAll('xpath', '//option');
 
-        $actualOptTexts = array_map(function ($actualOpt) {
-            /* @var NodeElement $actualOpt */
-            return $actualOpt->getText();
-        }, $actualOpts);
+            if (count($actualOpts) == 0) {
+                throw new ExpectationException('No option found in the select', $this->getSession());
+            }
 
-        if (count($actualOptTexts) > count($expectedOptTexts)) {
-            throw new ExpectationException('Select has more option then expected', $this->getSession());
-        }
+            $actualOptTexts = array_map(function ($actualOpt) {
+                /* @var NodeElement $actualOpt */
+                return $actualOpt->getText();
+            }, $actualOpts);
 
-        if (count($actualOptTexts) < count($expectedOptTexts)) {
-            throw new ExpectationException('Select has less option then expected', $this->getSession());
-        }
+            if (count($actualOptTexts) > count($expectedOptTexts)) {
+                throw new ExpectationException('Select has more option then expected', $this->getSession());
+            }
 
-        if ($actualOptTexts != $expectedOptTexts) {
-            $intersect = array_intersect($actualOptTexts, $expectedOptTexts);
+            if (count($actualOptTexts) < count($expectedOptTexts)) {
+                throw new ExpectationException('Select has less option then expected', $this->getSession());
+            }
 
-            if (count($intersect) < count($expectedOptTexts)) {
+            if ($actualOptTexts != $expectedOptTexts) {
+                $intersect = array_intersect($actualOptTexts, $expectedOptTexts);
+
+                if (count($intersect) < count($expectedOptTexts)) {
+                    throw new ExpectationException(
+                        'Expecting ' . count($expectedOptTexts) . ' matching option(s), found ' . count($intersect),
+                        $this->getSession()
+                    );
+                }
+
                 throw new ExpectationException(
-                    'Expecting ' . count($expectedOptTexts) . ' matching option(s), found ' . count($intersect),
+                    'Options in select match expected but not in expected order',
                     $this->getSession()
                 );
             }
-
-            throw new ExpectationException(
-                'Options in select match expected but not in expected order',
-                $this->getSession()
-            );
-        }
+        });
     }
 
     /**

--- a/web/select-option.html
+++ b/web/select-option.html
@@ -17,5 +17,20 @@
         <select id="state">
         </select>
     </form>
+    <button onclick="updateSelectWithDelay()">Update select with delay</button>
+<script>
+    function updateSelectWithDelay() {
+        setTimeout(function() {
+            let select = document.getElementById('country');
+
+            ['Australia', 'New Zealand', 'Japan'].forEach(function (value) {
+                let option = document.createElement('option');
+                option.value = value;
+                option.text = value;
+                select.add(option);
+            });
+        }, 2000);
+    }
+</script>
 </body>
 </html>


### PR DESCRIPTION
Note: This is the v2.0 fork of \#144

Problem:
I need to be able to test for options in a select that are added via an asynchronous process. The method currently fails immediately if the options are not present.

Fix:
I modified the method to use a waitFor()