### PR TITLE
Addition of step and test for Partially match Tables.

### DIFF
--- a/features/TableContext.feature
+++ b/features/TableContext.feature
@@ -64,3 +64,10 @@ Feature: Table Context
     Then there should be a table on the page with the following information:
       | Test Column                             |
       | Testing Column with Hidden Nested Table |
+
+  Scenario: Developer can Test a table with partial rows
+    Then the table "population-table" should contain the following values:
+      | Country                  | Female Population |
+      | India                    | 592,067,546       |
+      | China                    | 644,994,400       |
+      | United States of America | 157,244,385       |

--- a/src/Behat/FlexibleMink/Context/TableContext.php
+++ b/src/Behat/FlexibleMink/Context/TableContext.php
@@ -483,4 +483,67 @@ trait TableContext
             );
         });
     }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @Then the table :name should contain the following values:
+     */
+    public function assertTableShouldContainTheFollowingValues($name, TableNode $tableNode)
+    {
+        $table = $this->getTableFromName($name);
+        $expected = $tableNode->getColumnsHash();
+
+        $actual = array_map(function (array $row) use ($table) {
+            return array_combine($table['colHeaders'], $row);
+        }, $table['body']);
+
+        foreach ($expected as $row) {
+            if (($key = $this->rowExistsInTable($row, $actual)) === false) {
+                throw new ExpectationException(
+                    'Row not found...',
+                    $this->getSession());
+            }
+
+            unset($actual[$key]);
+        }
+    }
+
+    /**
+     * Checks if the expected row exists in the table provided and returns the row key where it was found.
+     *
+     * @param array $expectedRow The that is expected in the table.
+     * @param array $table       The table to find row
+     *
+     * @return int|bool False when the row was not found or the key where the row was found
+     **/
+    protected function rowExistsInTable($expectedRow, $table)
+    {
+        foreach ($table as $key => $actualRow) {
+            if ($this->rowContains($expectedRow, $actualRow)) {
+                return $key;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Checks if the columns are found on the row.
+     *
+     * @param array $cols The columns to be found on the row
+     * @param array $row  The the row to inspect.
+     *
+     * @return bool whether the row has the values and all columns expected.
+     **/
+    protected function rowContains($cols, $row)
+    {
+        foreach ($cols as $key => $val) {
+            if (!array_key_exists($key, $row) || $row[$key] != $val) {
+                return false;
+            }
+        }
+
+        return true;
+    }
 }

--- a/src/Behat/FlexibleMink/Context/TableContext.php
+++ b/src/Behat/FlexibleMink/Context/TableContext.php
@@ -499,7 +499,7 @@ trait TableContext
         }, $table['body']);
 
         foreach ($expected as $row) {
-            if (($key = $this->rowExistsInTable($row, $actual)) === false) {
+            if (($key = $this->getTableRow($row, $actual)) === -1) {
                 throw new ExpectationException(
                     'Row not found...',
                     $this->getSession());
@@ -515,9 +515,9 @@ trait TableContext
      * @param array $expectedRow The that is expected in the table.
      * @param array $table       The table to find row
      *
-     * @return int|bool False when the row was not found or the key where the row was found
+     * @return int False when the row was not found or the key where the row was found
      **/
-    protected function rowExistsInTable($expectedRow, $table)
+    protected function getTableRow($expectedRow, $table)
     {
         foreach ($table as $key => $actualRow) {
             if ($this->rowContains($expectedRow, $actualRow)) {
@@ -525,7 +525,7 @@ trait TableContext
             }
         }
 
-        return false;
+        return -1;
     }
 
     /**

--- a/src/Behat/FlexibleMink/PseudoInterface/TableContextInterface.php
+++ b/src/Behat/FlexibleMink/PseudoInterface/TableContextInterface.php
@@ -103,4 +103,13 @@ trait TableContextInterface
      * @return array  An array containing parsed rows and cells as returned form $this->buildTableFromHtml
      */
     abstract public function getTableFromName($name, $forceFresh = false);
+
+    /**
+     * Asserts that the table contains a row with the provided values.
+     *
+     * @param  string               $name      The name of the table
+     * @param  TableNode            $tableNode The list of values to search.
+     * @throws ExpectationException If the values are not found in the table.
+     */
+    abstract public function assertTableShouldContainTheFollowingValues($name, TableNode $tableNode);
 }


### PR DESCRIPTION
This will allow to find a table on the page without the need of `| * |` for empty values or values/columns that are not needed to be tested.