### PR TITLE
Partially Match Tables V2.0

### DIFF
--- a/features/TableContext.feature
+++ b/features/TableContext.feature
@@ -59,3 +59,10 @@ Feature: Table Context
      And the table "table-with-select" should have the following values:
       | Name    | Zhang |
       | Country | China |
+
+  Scenario: Developer can Test a table with partial rows
+    Then the table "population-table" should contain the following values:
+      | Country                  | Female Population |
+      | India                    | 592,067,546       |
+      | China                    | 644,994,400       |
+      | United States of America | 157,244,385       |

--- a/src/Medology/Behat/Mink/TableContext.php
+++ b/src/Medology/Behat/Mink/TableContext.php
@@ -538,7 +538,7 @@ class TableContext implements Context
         }, $table['body']);
 
         foreach ($expected as $row) {
-            if (($key = $this->getTableRow($row, $actual)) === -1) {
+            if (($key = $this->getTableRowIndex($row, $actual)) === -1) {
                 throw new ExpectationException(
                     'Row not found...',
                     $this->flexibleContext->getSession());
@@ -556,7 +556,7 @@ class TableContext implements Context
      *
      * @return int False when the row was not found or the key where the row was found
      **/
-    protected function getTableRow($expectedRow, $table)
+    protected function getTableRowIndex($expectedRow, $table)
     {
         foreach ($table as $key => $actualRow) {
             if ($this->rowContains($expectedRow, $actualRow)) {

--- a/src/Medology/Behat/Mink/TableContext.php
+++ b/src/Medology/Behat/Mink/TableContext.php
@@ -519,4 +519,70 @@ class TableContext implements Context
             $this->flexibleContext->getSession()
         );
     }
+
+    /**
+     * Asserts that the table contains a row with the provided values.
+     *
+     * @Then the table :name should contain the following values:
+     * @param  string               $name      The name of the table
+     * @param  TableNode            $tableNode The list of values to search.
+     * @throws ExpectationException If the values are not found in the table.
+     */
+    public function assertTableShouldContainTheFollowingValues($name, TableNode $tableNode)
+    {
+        $table = $this->getTableFromName($name);
+        $expected = $tableNode->getColumnsHash();
+
+        $actual = array_map(function (array $row) use ($table) {
+            return array_combine($table['colHeaders'], $row);
+        }, $table['body']);
+
+        foreach ($expected as $row) {
+            if (($key = $this->getTableRow($row, $actual)) === -1) {
+                throw new ExpectationException(
+                    'Row not found...',
+                    $this->flexibleContext->getSession());
+            }
+
+            unset($actual[$key]);
+        }
+    }
+
+    /**
+     * Checks if the expected row exists in the table provided and returns the row key where it was found.
+     *
+     * @param array $expectedRow The that is expected in the table.
+     * @param array $table       The table to find row
+     *
+     * @return int False when the row was not found or the key where the row was found
+     **/
+    protected function getTableRow($expectedRow, $table)
+    {
+        foreach ($table as $key => $actualRow) {
+            if ($this->rowContains($expectedRow, $actualRow)) {
+                return $key;
+            }
+        }
+
+        return -1;
+    }
+
+    /**
+     * Checks if the columns are found on the row.
+     *
+     * @param array $cols The columns to be found on the row
+     * @param array $row  The the row to inspect.
+     *
+     * @return bool whether the row has the values and all columns expected.
+     **/
+    protected function rowContains($cols, $row)
+    {
+        foreach ($cols as $key => $val) {
+            if (!array_key_exists($key, $row) || $row[$key] != $val) {
+                return false;
+            }
+        }
+
+        return true;
+    }
 }


### PR DESCRIPTION
Note: This is the v 2.0 version of #146

This will allow to find a table on the page without the need of | * | for empty values or values/columns that are not needed to be tested.