### PR TITLE
Change the regex for castStringToInt function

### DIFF
--- a/src/Behat/FlexibleMink/Context/TypeCaster.php
+++ b/src/Behat/FlexibleMink/Context/TypeCaster.php
@@ -10,7 +10,7 @@ trait TypeCaster
     /**
      * Casts a step argument from a string to an int.
      *
-     * @Transform /^(\d+)$/
+     * @Transform /^((?!(0))[0-9]+)$/
      * @param  string $string the string to cast.
      * @return int    The resulting int.
      */


### PR DESCRIPTION
Change the Regex so that it won't take any string that starts with "0"
It's for the behat test contains zipcode, so that we don't need to hack with single quote inside double quote  like "'07093'" anymore.