### PR TITLE
Change regex for castStringToInit

### DIFF
--- a/src/Medology/Behat/TypeCaster.php
+++ b/src/Medology/Behat/TypeCaster.php
@@ -10,7 +10,7 @@ trait TypeCaster
     /**
      * Casts a step argument from a string to an int.
      *
-     * @Transform /^(\d+)$/
+     * @Transform /^([1-9]\d*)$/
      * @param  string $string the string to cast.
      * @return int    The resulting int.
      */


### PR DESCRIPTION
Same PR as https://github.com/Medology/FlexibleMink/pull/151
Instead of pushing to master branch, push it to both 1.0 and 2.0 branch  since all changes should be submitted to both 1.0 and 2.0 (assuming they make sense for both). 1.0 is deprecated, so all projects using it should plan to move to 2.0.

**Problem I'm solving**
It's for the behat test contains zipcode, right now If I input "07093", the output will be "7093". And I have to hack with single quote inside double quote like "'07093'"

**How my change solves it.**
Change the Regex so that it won't take any string that starts with "0"
