### PR TITLE
Specify format when injecting values

### DIFF
--- a/src/Behat/FlexibleMink/Context/StoreContext.php
+++ b/src/Behat/FlexibleMink/Context/StoreContext.php
@@ -21,6 +21,8 @@ trait StoreContext
     /** @var array */
     protected $registry;
 
+    protected static $dateFormat = DateTime::ISO8601;
+
     protected static $FORMAT_MYSQL_DATE = 'a MySQL date';
     protected static $FORMAT_MYSQL_DATE_AND_TIME = 'a MySQL date and time';
     protected static $FORMAT_US_DATE = 'a US date';
@@ -257,7 +259,7 @@ trait StoreContext
         } elseif (is_object($thing)) {
             $value = $this->formatDateTimeFromHostObject($dateTime, $thing);
         } else {
-            return $this->formatDateTimeWithoutHostObject($dateTime);
+            $value = $this->formatDateTimeWithoutHostObject($dateTime);
         }
 
         return $value;
@@ -289,14 +291,14 @@ trait StoreContext
      * Formats a DateTime without taking into account the config of its host object.
      *
      * @param  DateTime $dateTime the date time to format.
-     * @return string   the result of calling __toString() on the date time, or formatting it as ISO8601 if no
-     *                           __toString method exists.
+     * @return string   the result of calling __toString() on the date time, or formatting it as static::$dateFormat if
+     *                           no __toString method exists.
      */
     protected function formatDateTimeWithoutHostObject(DateTime $dateTime)
     {
         return method_exists($dateTime, '__toString')
             ? (string) $dateTime
-            : $dateTime->format(DateTime::ISO8601);
+            : $dateTime->format(static::$dateFormat);
     }
 
     /**
@@ -319,7 +321,6 @@ trait StoreContext
 
                 $value = $property->getValue($object);
             } catch (ReflectionException $e) {
-                echo "Caught ReflectionException\n";
                 // do nothing
             }
         }

--- a/src/Behat/FlexibleMink/Context/StoreContext.php
+++ b/src/Behat/FlexibleMink/Context/StoreContext.php
@@ -254,10 +254,10 @@ trait StoreContext
     {
         if ($format) {
             $value = $dateTime->format($format);
-        } elseif (is_object($thing)) {
+        } else if (is_object($thing)) {
             $value = $this->formatDateTimeFromHostObject($dateTime, $thing);
         } else {
-            $value = (string) $dateTime;
+            return $this->formatDateTimeWithoutHostObject($dateTime);
         }
 
         return $value;
@@ -282,7 +282,21 @@ trait StoreContext
     {
         return ($format = $this->getPropertyValue($object, 'dateFormat'))
             ? $dateTime->format($format)
-            : (string) $dateTime;
+            : $this->formatDateTimeWithoutHostObject($dateTime);
+    }
+
+    /**
+     * Formats a DateTime without taking into account the config of its host object.
+     *
+     * @param  DateTime $dateTime the date time to format.
+     * @return string   the result of calling __toString() on the date time, or formatting it as ISO8601 if no
+     *                           __toString method exists.
+     */
+    protected function formatDateTimeWithoutHostObject(DateTime $dateTime)
+    {
+        return method_exists($dateTime, '__toString')
+            ? (string) $dateTime
+            : $dateTime->format(DateTime::ISO8601);
     }
 
     /**

--- a/src/Behat/FlexibleMink/Context/StoreContext.php
+++ b/src/Behat/FlexibleMink/Context/StoreContext.php
@@ -254,7 +254,7 @@ trait StoreContext
     {
         if ($format) {
             $value = $dateTime->format($format);
-        } else if (is_object($thing)) {
+        } elseif (is_object($thing)) {
             $value = $this->formatDateTimeFromHostObject($dateTime, $thing);
         } else {
             return $this->formatDateTimeWithoutHostObject($dateTime);

--- a/src/Behat/FlexibleMink/Context/StoreContext.php
+++ b/src/Behat/FlexibleMink/Context/StoreContext.php
@@ -280,28 +280,37 @@ trait StoreContext
      */
     protected function formatDateTimeFromHostObject(DateTime $dateTime, $object)
     {
-        return ($format = $this->getPrivatePropertyValue($object, 'dateFormat'))
+        return ($format = $this->getPropertyValue($object, 'dateFormat'))
             ? $dateTime->format($format)
             : (string) $dateTime;
     }
 
     /**
-     * Attempts to get the value of a non-public property on an object.
+     * Attempts to get the value of a property (public or otherwise) on an object.
      *
      * @param  object     $object       the object to read the property from.
      * @param  string     $propertyName the name of the property to read.
      * @return mixed|null the value of the property. Will return null if the property does not exist.
      */
-    protected function getPrivatePropertyValue($object, $propertyName)
+    protected function getPropertyValue($object, $propertyName)
     {
-        try {
-            $property = new ReflectionProperty(get_class($object), $propertyName);
-            $property->setAccessible(true);
+        $value = null;
 
-            return $property->getValue($object);
-        } catch (ReflectionException $e) {
-            return;
+        if (isset($object->$propertyName)) {
+            $value = $object->$propertyName;
+        } else {
+            try {
+                $property = new ReflectionProperty(get_class($object), $propertyName);
+                $property->setAccessible(true);
+
+                $value = $property->getValue($object);
+            } catch (ReflectionException $e) {
+                echo "Caught ReflectionException\n";
+                // do nothing
+            }
         }
+
+        return $value;
     }
 
     /**

--- a/src/Behat/FlexibleMink/Context/StoreContext.php
+++ b/src/Behat/FlexibleMink/Context/StoreContext.php
@@ -21,12 +21,17 @@ trait StoreContext
     /** @var array */
     protected $registry;
 
+    protected static $FORMAT_MYSQL_DATE = 'a MySQL date';
     protected static $FORMAT_MYSQL_DATE_AND_TIME = 'a MySQL date and time';
+    protected static $FORMAT_US_DATE = 'a US date';
+    protected static $FORMAT_US_DATE_AND_TIME = 'a US date and time';
+    protected static $FORMAT_US_DATE_AND_12HR_TIME = 'a US date and 12hr time';
     protected static $format_map = [
-        'a MySQL date'          => 'Y-m-d',
-        'a MySQL date and time' => 'Y-m-d H:i:s',
-        'a US date'             => 'm-d-Y',
-        'a US date and time'    => 'm-d-Y H:i:s',
+        'a MySQL date'            => 'Y-m-d',
+        'a MySQL date and time'   => 'Y-m-d H:i:s',
+        'a US date'               => 'm/d/Y',
+        'a US date and time'      => 'm/d/Y H:i:s',
+        'a US date and 12hr time' => 'm/d/Y \a\t g:i A',
     ];
 
     /**
@@ -158,8 +163,6 @@ trait StoreContext
             $thingName = $matches[2][$i];
             $thingProperty = str_replace(' ', '_', strtolower($matches[1][$i]));
             $thingFormat = $matches[4][$i];
-
-            //dump($matches);
 
             if (!$this->isStored($thingName)) {
                 throw new Exception("Did not find $thingName in the store");

--- a/tests/Behat/FlexibleMink/Context/StoreContextTest.php
+++ b/tests/Behat/FlexibleMink/Context/StoreContextTest.php
@@ -1,6 +1,7 @@
 <?php namespace Tests\Behat\FlexibleMink\Context;
 
 use Behat\FlexibleMink\Context\StoreContext;
+use DateTime;
 use Exception;
 use PHPUnit_Framework_Error;
 use PHPUnit_Framework_TestCase;
@@ -28,6 +29,7 @@ class StoreContextTest extends PHPUnit_Framework_TestCase
             'test_property_1' => 'test_value_1',
             'test_property_2' => 'test_value_2',
             'test_property_3' => 'test_value_3',
+            'date_prop'       => new DateTime('2028-10-28 15:30:10'),
         ];
 
         return $obj;
@@ -330,6 +332,32 @@ class StoreContextTest extends PHPUnit_Framework_TestCase
                     return isset($thing->$property);
                 }
             )
+        );
+
+        /******************************
+         * Formatted as
+         *****************************/
+
+        // DateTime is formatted with default format when no format is specified
+        $this->assertEquals('2028-10-28T15:30:10+0000', $this->injectStoredValues('(the date_prop of the testObj)'));
+
+        // DateTime is formatted with specified format
+        $this->assertEquals(
+            '10/28/2028',
+            $this->injectStoredValues('(the date_prop of the testObj formatted as a US date)')
+        );
+
+        // DateTime is formatted as per host object format
+        $testObj->dateFormat = 'm/d/Y H:i';
+        $this->assertEquals(
+            '10/28/2028 15:30',
+            $this->injectStoredValues('(the date_prop of the testObj)')
+        );
+
+        // DateTime is formatted as specified format, even if host object has format
+        $this->assertEquals(
+            '10/28/2028 at 3:30 PM',
+            $this->injectStoredValues('(the date_prop of the testObj formatted as a US date and 12hr time)')
         );
     }
 


### PR DESCRIPTION
# Problem:
The injectStoredValues method is simplistic in that it injects the stored value as is without any context. For the most part this is fine, but sometimes we have a model that has a DateTime which is being displayed by the presentation tier using a different format. For example, the created_at property of a model might include hours, mins and seconds, but the front-end may decide that they only wish to display year, month and day (probably in standard US format). If the stringified date from the store does not match how the front-end is presenting it, then it's not possible to say something like `I should see (the created at date of the order)`.

# Fix:
I implemented the ability to specify a format for the injected value. For example `I should see (the created date of the order as a US date)`. I added a few useful formats, and developers can easily add more as needed.