### PR TITLE
Fix "0" is not converted to int

### DIFF
--- a/src/Behat/FlexibleMink/Context/TypeCaster.php
+++ b/src/Behat/FlexibleMink/Context/TypeCaster.php
@@ -10,7 +10,7 @@ trait TypeCaster
     /**
      * Casts a step argument from a string to an int.
      *
-     * @Transform /^([1-9]\d*)$/
+     * @Transform /^(0|[1-9]\d*)$/
      * @param  string $string the string to cast.
      * @return int    The resulting int.
      */


### PR DESCRIPTION
# Problem:
Providing 0 for a parameter value in a Behat step does not get converted to int.

# Cause:
The pattern was recently updated to exclude numbers prefixed with 0 so that zip codes starting with zero would not be converted to int. The change did not take into account the scenario where the only digit is 0.

# Fix:
I modified the pattern to convert a single 0 to an integer in addition to all numbers that are two or more digits that do not start with a zero.