### PR TITLE
Add AsyncMink class

### DIFF
--- a/src/Medology/Behat/Mink/AsyncMink.php
+++ b/src/Medology/Behat/Mink/AsyncMink.php
@@ -1,0 +1,46 @@
+<?php namespace Medology\Behat\Mink;
+
+use Exception;
+use Medology\Spinner;
+
+/**
+ * Wraps the FlexibleMink context to provide asynchronous assertions.
+ *
+ * The methods here will wait for either the assertion to pass, or for the timeout to expire.
+ *
+ * See Spinner::$default_timeout
+ *
+ * This is purely for use when calling these methods programmatically. This class is NOT a context class and should
+ * not be used as such. Async functionality for context classes should be handled by use of the BehatRetryExtension
+ * https://github.com/Chekote/BehatRetryExtension.
+ *
+ * @mixin FlexibleContext
+ */
+class AsyncMink
+{
+    /** @var FlexibleContext */
+    protected $flexibleContext;
+
+    /**
+     * @param FlexibleContext $flexibleContext the instance to wrap.
+     */
+    public function __construct(FlexibleContext $flexibleContext)
+    {
+        $this->flexibleContext = $flexibleContext;
+    }
+
+    /**
+     * Proxy method to handle all calls and relay them to FlexibleContext wrapped in a waitFor.
+     *
+     * @param  string    $method    the name of the method that was called.
+     * @param  array     $arguments the arguments that were passed to the method.
+     * @throws Exception if the assertion did not pass before the timeout was exceeded.
+     * @return mixed     the result of the lambda if it succeeds.
+     */
+    public function __call($method, array $arguments)
+    {
+        return Spinner::waitFor(function () use ($method, $arguments) {
+            return call_user_func_array([$this->flexibleContext, $method], $arguments);
+        });
+    }
+}

--- a/src/Medology/Behat/Mink/FlexibleContext.php
+++ b/src/Medology/Behat/Mink/FlexibleContext.php
@@ -42,6 +42,14 @@ class FlexibleContext extends MinkContext
         'tab'        => 9,
     ];
 
+    /** @var AsyncMink */
+    protected $wait;
+
+    public function __construct()
+    {
+        $this->wait = new AsyncMink($this);
+    }
+
     /**
      * {@inheritdoc}
      *
@@ -320,7 +328,7 @@ class FlexibleContext extends MinkContext
     public function clickLink($locator)
     {
         $locator = $this->storeContext->injectStoredValues($locator);
-        $this->assertVisibleLink($locator)->click();
+        $this->wait->assertVisibleLink($locator)->click();
     }
 
     /**
@@ -346,7 +354,7 @@ class FlexibleContext extends MinkContext
     public function checkOption($locator)
     {
         $locator = $this->storeContext->injectStoredValues($locator);
-        $this->assertVisibleOption($locator)->check();
+        $this->wait->assertVisibleOption($locator)->check();
     }
 
     /**
@@ -373,7 +381,7 @@ class FlexibleContext extends MinkContext
     {
         $field = $this->storeContext->injectStoredValues($field);
         $value = $this->storeContext->injectStoredValues($value);
-        $this->assertFieldExists($field)->setValue($value);
+        $this->wait->assertFieldExists($field)->setValue($value);
     }
 
     /**
@@ -395,12 +403,13 @@ class FlexibleContext extends MinkContext
     public function uncheckOption($locator)
     {
         $locator = $this->storeContext->injectStoredValues($locator);
-        $this->assertVisibleOption($locator)->uncheck();
+        $this->wait->assertVisibleOption($locator)->uncheck();
     }
 
     /**
      * Checks if the selected button is disabled.
      *
+     * @todo   fix Given used with Then (incompatible)
      * @Given  the :locator button is :disabled
      * @Then   the :locator button should be :disabled
      * @param  string                           $locator  The button
@@ -942,11 +951,14 @@ class FlexibleContext extends MinkContext
      * @param  string                           $locator The field to blur
      * @throws DriverException                  When the operation cannot be performed.
      * @throws ExpectationException             if the specified field does not exist.
+     * @throws ReflectionException              If injectStoredValues incorrectly believes one or more closures were
+     *                                                  passed. This should never happen. If it does, there is a
+     *                                                  problem with the injectStoredValues method.
      * @throws UnsupportedDriverActionException When operation not supported by the driver.
      */
     public function blurField($locator)
     {
-        $this->assertFieldExists($locator)->blur();
+        $this->wait->assertFieldExists($locator)->blur();
     }
 
     /**
@@ -957,6 +969,9 @@ class FlexibleContext extends MinkContext
      * @param  string                           $locator The field to focus and blur
      * @throws DriverException                  When the operation cannot be performed.
      * @throws ExpectationException             if the specified field does not exist.
+     * @throws ReflectionException              If injectStoredValues incorrectly believes one or more closures were
+     *                                                  passed. This should never happen. If it does, there is a
+     *                                                  problem with the injectStoredValues method.
      * @throws UnsupportedDriverActionException When operation not supported by the driver.
      */
     public function focusBlurField($locator)
@@ -972,11 +987,14 @@ class FlexibleContext extends MinkContext
      * @param  string                           $locator The the field to focus
      * @throws DriverException                  When the operation cannot be performed.
      * @throws ExpectationException             if the specified field does not exist.
+     * @throws ReflectionException              If injectStoredValues incorrectly believes one or more closures were
+     *                                                  passed. This should never happen. If it does, there is a
+     *                                                  problem with the injectStoredValues method.
      * @throws UnsupportedDriverActionException When operation not supported by the driver.
      */
     public function focusField($locator)
     {
-        $this->assertFieldExists($locator)->focus();
+        $this->wait->assertFieldExists($locator)->focus();
     }
 
     /**
@@ -1012,11 +1030,7 @@ class FlexibleContext extends MinkContext
      */
     public function pressButton($locator)
     {
-        /** @var NodeElement $button */
-        /** @noinspection PhpUnhandledExceptionInspection */
-        $button = Spinner::waitFor(function () use ($locator) {
-            return $this->assertVisibleButton($locator);
-        });
+        $button = $this->wait->assertVisibleButton($locator);
 
         /* @noinspection PhpUnhandledExceptionInspection */
         Spinner::waitFor(function () use ($button, $locator) {


### PR DESCRIPTION
# Requirement:
There are various instances where Behat steps are not "Then" steps, but they require a certain level of retry functionality. For example, with complex "When" steps that interact with the page and then need to wait for a button to be visible etc before proceeding. Since currently the only retry functionality is implemented in the BehatRetryExtension, which only works when steps are invoked from the feature file, none of these use cases are catered to.

# Implementation:
I wrote an AsyncMink class which can be used to programmatically make assertions via the Spinner::waitFor mechanism. This prevents having all users of the FlexibleMink library from having to sprinkle waitFor calls throughout their code by centralizing the behavior in this class.

This is purely for use when calling these methods programmatically. This class is NOT a context class and should not be used as such. Async functionality for context classes should be handled by use of the BehatRetryExtension https://github.com/Chekote/BehatRetryExtension

Please note that this class references exception that is either thrown or do not exist yet. This is because this PR is made assuming #170 is merged first.