### PR TITLE
Move assertElementOnPage from STDcheck to FlexibleMink

### DIFF
--- a/src/Medology/Behat/Mink/FlexibleContext.php
+++ b/src/Medology/Behat/Mink/FlexibleContext.php
@@ -142,6 +142,25 @@ class FlexibleContext extends MinkContext
     }
 
     /**
+     * {@inheritdoc}
+     *
+     * Overrides the base method store the resulting element in the store under "element" and return it.
+     *
+     * @param  string                   $element      The selector to find the element.
+     * @param  string                   $selectorType css|xpath selector type to find the element.
+     * @throws ElementNotFoundException if the element was not found.
+     * @return NodeElement              The element found.
+     */
+    public function assertElementOnPage($element, $selectorType = 'css')
+    {
+        $node = $this->assertSession()->elementExists($selectorType, $element);
+
+        $this->storeContext->set('element', $node);
+
+        return $node;
+    }
+
+    /**
      * Clicks a visible link with specified id|title|alt|text.
      *
      * This method overrides the MinkContext::clickLink() default behavior for clickLink to ensure that only visible


### PR DESCRIPTION
Various methods were added to STDcheck's WebContext instead of adding them to FlexibleMink. This is the first of many PRs that will move these methods so that all projects using FlexibleMink can utilize them.