### PR TITLE
Move assertElementInsideElement from STDcheck to FlexibleMink

### DIFF
--- a/src/Medology/Behat/Mink/FlexibleContext.php
+++ b/src/Medology/Behat/Mink/FlexibleContext.php
@@ -142,6 +142,24 @@ class FlexibleContext extends MinkContext
     }
 
     /**
+     * Asserts that an element with the given XPath is present in the container, and returns it.
+     *
+     * @param  NodeElement          $container The base element to search in.
+     * @param  string               $xpath     The XPath of the element to locate inside the container.
+     * @throws DriverException      When the operation cannot be done
+     * @throws ExpectationException if no element was found.
+     * @return NodeElement          The found element.
+     */
+    public function assertElementInsideElement(NodeElement $container, $xpath)
+    {
+        if (!$element = $container->find('xpath', $xpath)) {
+            throw new ExpectationException('Nothing found inside element with xpath $xpath', $this->getSession());
+        }
+
+        return $element;
+    }
+
+    /**
      * Clicks a visible link with specified id|title|alt|text.
      *
      * This method overrides the MinkContext::clickLink() default behavior for clickLink to ensure that only visible


### PR DESCRIPTION
Various methods were added to STDcheck's WebContext instead of adding them to FlexibleMink. This is one of many PRs that will move these methods so that all projects using FlexibleMink can utilize them.