### PR TITLE
Move assertElementInsideElement from STDcheck to FlexibleMink

### DIFF
--- a/src/Behat/FlexibleMink/Context/FlexibleContext.php
+++ b/src/Behat/FlexibleMink/Context/FlexibleContext.php
@@ -165,6 +165,24 @@ class FlexibleContext extends MinkContext
     }
 
     /**
+     * Asserts that an element with the given XPath is present in the container, and returns it.
+     *
+     * @param  NodeElement          $container The base element to search in.
+     * @param  string               $xpath     The XPath of the element to locate inside the container.
+     * @throws DriverException      When the operation cannot be done
+     * @throws ExpectationException if no element was found.
+     * @return NodeElement          The found element.
+     */
+    public function assertElementInsideElement(NodeElement $container, $xpath)
+    {
+        return $this->waitFor(function () use ($container, $xpath) {
+            if (!$element = $container->find('xpath', $xpath)) {
+                throw new ExpectationException('Nothing found inside element with xpath $xpath', $this->getSession());
+            }
+        });
+    }
+
+    /**
      * {@inheritdoc}
      */
     public function assertElementNotContainsText($element, $text)


### PR DESCRIPTION
Various methods were added to STDcheck's WebContext instead of adding them to FlexibleMink. This is one of many PRs that will move these methods so that all projects using FlexibleMink can utilize them.