### PR TITLE
Move assertFieldContains from STDcheck to FlexibleMink

### DIFF
--- a/src/Behat/FlexibleMink/Context/FlexibleContext.php
+++ b/src/Behat/FlexibleMink/Context/FlexibleContext.php
@@ -46,6 +46,9 @@ class FlexibleContext extends MinkContext
      */
     public function assertFieldContains($field, $value)
     {
+        $field = $this->injectStoredValues($field);
+        $value = $this->injectStoredValues($value);
+
         $this->waitFor(function () use ($field, $value) {
             parent::assertFieldContains($field, $value);
         });


### PR DESCRIPTION
Various methods were added to STDcheck's WebContext instead of adding them to FlexibleMink. This is one of many PRs that will move these methods so that all projects using FlexibleMink can utilize them.