### PR TITLE
Move assertFieldContains from STDcheck to FlexibleMink

### DIFF
--- a/src/Medology/Behat/Mink/FlexibleContext.php
+++ b/src/Medology/Behat/Mink/FlexibleContext.php
@@ -84,6 +84,19 @@ class FlexibleContext extends MinkContext
     }
 
     /**
+     * {@inheritdoc}
+     *
+     * Overrides the parent method to support injecting values from the store into the field and value.
+     */
+    public function assertFieldContains($field, $value)
+    {
+        $field = $this->injectStoredValues($field);
+        $value = $this->injectStoredValues($value);
+
+        parent::assertFieldContains($field, $value);
+    }
+
+    /**
      * Asserts that a field is visible or not.
      *
      * @Then   /^the field "(?P<field>[^"]+)" should(?P<not> not|) be visible$/


### PR DESCRIPTION
Various methods were added to STDcheck's WebContext instead of adding them to FlexibleMink. This is one of many PRs that will move these methods so that all projects using FlexibleMink can utilize them.