### PR TITLE
Move pressButton from STDcheck to FlexibleMink

### DIFF
--- a/src/Behat/FlexibleMink/Context/FlexibleContext.php
+++ b/src/Behat/FlexibleMink/Context/FlexibleContext.php
@@ -679,11 +679,18 @@ class FlexibleContext extends MinkContext
      */
     public function pressButton($locator)
     {
-        $element = $this->waitFor(function () use ($locator) {
+        /** @var NodeElement $button */
+        $button = $this->waitFor(function () use ($locator) {
             return $this->assertVisibleButton($locator);
         });
 
-        $element->press();
+        $this->waitFor(function () use ($button, $locator) {
+            if ($button->getAttribute('disabled') === 'disabled') {
+                throw new ExpectationException("Unable to press disabled button '$locator'.", $this->getSession());
+            }
+        });
+
+        $button->press();
     }
 
     /**


### PR DESCRIPTION
Various methods were added to STDcheck's WebContext instead of adding them to FlexibleMink. This is one of many PRs that will move these methods so that all projects using FlexibleMink can utilize them.