### PR TITLE
Move assertCheckboxChecked from STDcheck to FlexibleMink

### DIFF
--- a/src/Behat/FlexibleMink/Context/FlexibleContext.php
+++ b/src/Behat/FlexibleMink/Context/FlexibleContext.php
@@ -725,11 +725,16 @@ class FlexibleContext extends MinkContext
 
     /**
      * {@inheritdoc}
+     *
+     * Overrides the base method to inject stored values into the argument, and wait for the assertion to pass.
      */
     public function assertCheckboxChecked($checkbox)
     {
         $checkbox = $this->injectStoredValues($checkbox);
-        parent::assertCheckboxChecked($checkbox);
+
+        $this->waitFor(function () use ($checkbox) {
+            parent::assertCheckboxChecked($checkbox);
+        });
     }
 
     /**


### PR DESCRIPTION
Various methods were added to STDcheck's WebContext instead of adding them to FlexibleMink. This is one of many PRs that will move these methods so that all projects using FlexibleMink can utilize them.