### PR TITLE
Move comparElementsByCoords from STDcheck to FlexibleMink

### DIFF
--- a/src/Medology/Behat/Mink/FlexibleContext.php
+++ b/src/Medology/Behat/Mink/FlexibleContext.php
@@ -1110,7 +1110,11 @@ class FlexibleContext extends MinkContext
         /* @noinspection PhpUndefinedMethodInspection */
         $bRect = $driver->getXpathBoundingClientRect($b->getXpath());
 
-        return $aRect['top'] - $bRect['top'];
+        if ($aRect['top'] == $bRect['top']) {
+            return 0;
+        }
+
+        return ($aRect['top'] < $bRect['top']) ? -1 : 1;
     }
 
     /**


### PR DESCRIPTION
Various methods were added to STDcheck's WebContext instead of adding them to FlexibleMink. This is one of many PRs that will move these methods so that all projects using FlexibleMink can utilize them.