### PR TITLE
Move comparElementsByCoords from STDcheck to FlexibleMink

### DIFF
--- a/src/Behat/FlexibleMink/Context/FlexibleContext.php
+++ b/src/Behat/FlexibleMink/Context/FlexibleContext.php
@@ -861,6 +861,10 @@ class FlexibleContext extends MinkContext
         /* @noinspection PhpUndefinedMethodInspection */
         $bRect = $driver->getXpathBoundingClientRect($b->getXpath());
 
-        return $aRect['top'] - $bRect['top'];
+        if ($aRect['top'] == $bRect['top']) {
+            return 0;
+        }
+
+        return ($aRect['top'] < $bRect['top']) ? -1 : 1;
     }
 }


### PR DESCRIPTION
Various methods were added to STDcheck's WebContext instead of adding them to FlexibleMink. This is one of many PRs that will move these methods so that all projects using FlexibleMink can utilize them.