### PR TITLE
Move assertJavascriptVariables from STDcheck to FlexibleMink

### DIFF
--- a/src/Medology/Behat/Mink/JavaScriptContext.php
+++ b/src/Medology/Behat/Mink/JavaScriptContext.php
@@ -129,4 +129,20 @@ class JavaScriptContext implements Context
             );
         }
     }
+
+    /**
+     * Asserts that a set of javascript variables have specified values.
+     * The $table should have the variable name in the first column, and the value in the second.
+     *
+     * @param  TableNode            $table The variable names and values to check.
+     * @throws ExpectationException If variable value does not match expected value.
+     */
+    public function assertJavascriptVariables(TableNode $table)
+    {
+        $attributes = array_map([$this, 'injectStoredValues'], $table->getRowsHash());
+
+        foreach ($attributes as $key => $value) {
+            $this->assertJavascriptVariable($key, $value);
+        }
+    }
 }


### PR DESCRIPTION
Various methods were added to STDcheck's WebContext instead of adding them to FlexibleMink. This is one of many PRs that will move these methods so that all projects using FlexibleMink can utilize them.