### PR TITLE
Move elementHasAttributeValues from STDcheck to FlexibleMink

### DIFF
--- a/src/Medology/Behat/Mink/FlexibleContext.php
+++ b/src/Medology/Behat/Mink/FlexibleContext.php
@@ -1058,6 +1058,26 @@ class FlexibleContext extends MinkContext
     }
 
     /**
+     * Checks if a node has the specified attribute values.
+     *
+     * @param  NodeElement                      $node       The node to check the expected attributes against.
+     * @param  array                            $attributes An associative array of the expected attributes.
+     * @throws DriverException                  When the operation cannot be done
+     * @throws UnsupportedDriverActionException When operation not supported by the driver
+     * @return bool                             true if the element has the specified attribute values, false if not.
+     */
+    public function elementHasAttributeValues(NodeElement $node, array $attributes)
+    {
+        foreach ($attributes as $name => $value) {
+            if ($node->getAttribute($name) != $value) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
      * Locate the radio button by label.
      *
      * @param  string                           $label The Label of the radio button.


### PR DESCRIPTION
Various methods were added to STDcheck's WebContext instead of adding them to FlexibleMink. This is one of many PRs that will move these methods so that all projects using FlexibleMink can utilize them.