### PR TITLE
Move waitForPageLoad from STDcheck to FlexibleMink

### DIFF
--- a/src/Medology/Behat/Mink/FlexibleContext.php
+++ b/src/Medology/Behat/Mink/FlexibleContext.php
@@ -1149,7 +1149,9 @@ class FlexibleContext extends MinkContext
      * This does not wait for any particular javascript frameworks to be ready, it only waits for the DOM to be
      * ready. This is done by waiting for the document.readyState to be "complete".
      *
-     * @throws SpinnerTimeoutException If the timeout expires and the lambda has thrown a Exception.
+     * @noinspection PhpDocRedundantThrowsInspection exceptions bubble up from waitFor.
+     * @throws ExpectationException    If the page did not finish loading before the timeout expired.
+     * @throws SpinnerTimeoutException If the timeout expires before the assertion can be made even once.
      */
     public function waitForPageLoad()
     {

--- a/src/Medology/Behat/Mink/FlexibleContext.php
+++ b/src/Medology/Behat/Mink/FlexibleContext.php
@@ -1142,4 +1142,22 @@ class FlexibleContext extends MinkContext
     {
         return realpath(__DIR__ . '/../../../../artifacts');
     }
+
+    /**
+     * Waits for the page to be loaded.
+     *
+     * This does not wait for any particular javascript frameworks to be ready, it only waits for the DOM to be
+     * ready. This is done by waiting for the document.readyState to be "complete".
+     *
+     * @throws SpinnerTimeoutException If the timeout expires and the lambda has thrown a Exception.
+     */
+    public function waitForPageLoad()
+    {
+        Spinner::waitFor(function () {
+            $readyState = $this->getSession()->evaluateScript('document.readyState');
+            if ($readyState !== 'complete') {
+                throw new ExpectationException("Page is not loaded. Ready state is '$readyState'", $this->getSession());
+            }
+        });
+    }
 }

--- a/src/Medology/Spinner.php
+++ b/src/Medology/Spinner.php
@@ -17,7 +17,7 @@ class Spinner
      *
      * @param  callable                $lambda  The lambda to call. Must return true on success.
      * @param  int                     $timeout The number of seconds to spin for.
-     * @throws SpinnerTimeoutException If the timeout expires and the lambda has thrown a Exception.
+     * @throws SpinnerTimeoutException If the timeout expires before the assertion can be made even once.
      * @return mixed                   The result of the lambda if it succeeds.
      */
     public static function waitFor(callable $lambda, $timeout = null)


### PR DESCRIPTION
Various methods were added to STDcheck's WebContext instead of adding them to FlexibleMink. This is one of many PRs that will move these methods so that all projects using FlexibleMink can utilize them.