### PR TITLE
Move waitForPageLoad from STDcheck to FlexibleMink

### DIFF
--- a/src/Behat/FlexibleMink/Context/FlexibleContext.php
+++ b/src/Behat/FlexibleMink/Context/FlexibleContext.php
@@ -872,4 +872,20 @@ class FlexibleContext extends MinkContext
 
         return ($aRect['top'] < $bRect['top']) ? -1 : 1;
     }
+
+    /**
+     * Waits for the page to be loaded.
+     *
+     * This does not wait for any particular javascript frameworks to be ready, it only waits for the DOM to be
+     * ready. This is done by waiting for the document.readyState to be "complete".
+     */
+    public function waitForPageLoad($timeout = 120)
+    {
+        $this->waitFor(function () {
+            $readyState = $this->getSession()->evaluateScript('document.readyState');
+            if ($readyState !== 'complete') {
+                throw new ExpectationException("Page is not loaded. Ready state is '$readyState'", $this->getSession());
+            }
+        }, $timeout);
+    }
 }


### PR DESCRIPTION
Various methods were added to STDcheck's WebContext instead of adding them to FlexibleMink. This is one of many PRs that will move these methods so that all projects using FlexibleMink can utilize them.