### PR TITLE
Creating Method to Assert Element is not Covered by Another

### DIFF
--- a/features/FlexibleContext/assertElementIsNotCovered.feature
+++ b/features/FlexibleContext/assertElementIsNotCovered.feature
@@ -1,0 +1,13 @@
+Feature:  Assert Checkbox
+  In order to ensure that elements are interactive
+  As a developer
+  I should have assertions for elements covering others
+
+  Background:
+    Given I am on "/covering-elements.html"
+
+  Scenario: Assert element is not covered
+    When I assert that the "testedDiv" element should not be covered by another
+    Then the assertion should throw an ExpectationException
+     And the assertion should fail with the message 'An element is above an interacting element.'
+

--- a/features/FlexibleContext/assertElementIsNotCovered.feature
+++ b/features/FlexibleContext/assertElementIsNotCovered.feature
@@ -6,8 +6,23 @@ Feature:  Assert Checkbox
   Background:
     Given I am on "/covering-elements.html"
 
-  Scenario: Assert element is not covered
-    When I assert that the "testedDiv" element should not be covered by another
+  Scenario Outline: Assert Element is not covered
+    When I assert that the "<id>" element should not be covered by another
     Then the assertion should throw an ExpectationException
      And the assertion should fail with the message 'An element is above an interacting element.'
 
+    Examples:
+      | id           |
+      | testedDiv    |
+      | testedDiv_tl |
+      | testedDiv_tr |
+      | testedDiv_bl |
+      | testedDiv_br |
+
+  Scenario: Assert Calling Method on Covering Method Passes
+    When I assert that the "coveringDiv" element should not be covered by another
+    Then the assertion should pass
+
+  Scenario: Assert Uncovered Element Doesn't Throw Exception
+    When I assert that the "testedDiv_sbs" element should not be covered by another
+    Then the assertion should pass

--- a/src/Behat/FlexibleMink/Context/FlexibleContext.php
+++ b/src/Behat/FlexibleMink/Context/FlexibleContext.php
@@ -1189,8 +1189,8 @@ class FlexibleContext extends MinkContext
      * Keep in mind that at the moment, this method performs a check in a square area so this may not work
      * correctly with elements of different shapes.
      *
-     * @param  NodeElement              $element   The element to assert that is not covered by something else.
-     * @param  int                      $leniency  Percent of leniency when performing each pixel check.
+     * @param  NodeElement              $element  The element to assert that is not covered by something else.
+     * @param  int                      $leniency Percent of leniency when performing each pixel check.
      * @throws ExpectationException     If element is found to be covered by another.
      * @throws InvalidArgumentException The threshold provided is outside of the 0-100 range accepted.
      */
@@ -1218,8 +1218,7 @@ JS
         $x = $coordinates['left'];
         $y = $coordinates['top'];
 
-
-        $xSpacing = ($width * ($leniency/100)) ?: 1;
+        $xSpacing = ($width * ($leniency / 100)) ?: 1;
         $ySpacing = ($height * ($leniency / 100)) ?: 1;
 
         $expected = $element->getOuterHtml();
@@ -1236,7 +1235,6 @@ JS
             while ($x < $xLimit) {
                 $found = $this->getSession()->evaluateScript("return document.elementFromPoint($x, $y).outerHTML;");
                 if ($expected != $found) {
-
                     throw new ExpectationException(
                         'An element is above an interacting element.',
                         $this->getSession()
@@ -1252,14 +1250,13 @@ JS
             $assertRow($x, $y, $right);
             $y += $ySpacing;
         }
-
     }
 
     /**
      * Stipple drawing method for points specified on a page canvas.
      *
-     * @param int $x X coordinate where to place dot.
-     * @param int $y Y coordinate where to place dot.
+     * @param int    $x     X coordinate where to place dot.
+     * @param int    $y     Y coordinate where to place dot.
      * @param string $color The hex color code for the color of the point being drawn.  Keep in mind, the item will
      *                      appear semi transparent.
      *

--- a/src/Behat/FlexibleMink/Context/FlexibleContext.php
+++ b/src/Behat/FlexibleMink/Context/FlexibleContext.php
@@ -1253,30 +1253,6 @@ JS
     }
 
     /**
-     * Stipple drawing method for points specified on a page canvas.
-     *
-     * @param int    $x     X coordinate where to place dot.
-     * @param int    $y     Y coordinate where to place dot.
-     * @param string $color The hex color code for the color of the point being drawn.  Keep in mind, the item will
-     *                      appear semi transparent.
-     *
-     * @throws UnsupportedDriverActionException When operation not supported by the driver
-     * @throws DriverException                  When the operation cannot be done
-     */
-    protected function stipple($x, $y, $color = '#0f0')
-    {
-        $script = <<<JS
-(function () {
-        var point = document.createElement('div');
-        point.style.cssText = "position:absolute;top:{$y}px;left:{$x}px;width:1px;z-index:9999999;height:1px;" 
-            + "opacity: 0.5;background-color:$color";
-        document.body.appendChild(point);
-}());
-JS;
-        $this->getSession()->getDriver()->executeScript($script);
-    }
-
-    /**
      * Asserts that the current driver is Selenium 2 in preparation for performing an action that requires it.
      *
      * @param  string                           $operation the operation that you will attempt to perform that requires

--- a/web/covering-elements.html
+++ b/web/covering-elements.html
@@ -1,0 +1,31 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Assert Element is not Covered</title>
+    <style>
+        .samePositionElements {
+            position: absolute;
+            top: 0;
+            left: 0;
+            width: 150px;
+            height: 150px;
+        }
+
+        #testedDiv {
+            background-color: aquamarine;
+            z-index: 1;
+        }
+
+        #coveringDiv{
+            background-color: firebrick;
+            z-index: 999;
+        }
+    </style>
+</head>
+<body>
+    <div class="samePositionElements" id="testedDiv"></div>
+    <div class="samePositionElements" id="coveringDiv"></div>
+</body>
+</html>
+

--- a/web/covering-elements.html
+++ b/web/covering-elements.html
@@ -4,28 +4,118 @@
     <meta charset="UTF-8">
     <title>Assert Element is not Covered</title>
     <style>
-        .samePositionElements {
-            position: absolute;
-            top: 0;
-            left: 0;
-            width: 150px;
-            height: 150px;
+        .element {
+            width: 75px;
+            height: 75px;
+            position: fixed;
         }
 
-        #testedDiv {
+        .samePositionElements {
+            position: fixed;
+            top: 0;
+            left: 0;
+        }
+
+        .testingDiv {
             background-color: aquamarine;
             z-index: 1;
         }
 
-        #coveringDiv{
+        .coveringDiv{
             background-color: firebrick;
             z-index: 999;
+        }
+
+        .left {
+            left: 0px;
+        }
+
+        .right {
+            left: 32px;
+        }
+
+        /* Covering Top Left Elements */
+        #testedDiv_tl {
+            top: 135px;
+        }
+
+        #coveringDiv_tl {
+            top: 100px;
+        }
+
+        /* Covering Top Right Element */
+        #testedDiv_tr {
+            top: 300px;
+        }
+
+        #coveringDiv_tr {
+            top: 250px;
+        }
+
+        /* Covering Bottom Left */
+        #testedDiv_bl {
+            top: 400px;
+        }
+
+        #coveringDiv_bl {
+            top: 440px;
+        }
+
+        /* Covering Bottom Right */
+        #testedDiv_br {
+            top: 545px;
+        }
+
+        #coveringDiv_br {
+            top: 585px;
+        }
+
+        /* Covering Center */
+        #testedDiv_c {
+            top: 50px;
+            left: 200px;
+        }
+
+        #coveringDiv_c {
+            top: 70px;
+            left: 222px;
+
+            width: 32px;
+            height: 32px;
+        }
+
+        #testedDiv_sbs {
+            top: 70px;
+            left: 350px;
+        }
+
+        #adjacentDiv_sbs {
+            top: 70px;
+            left: 425px;
         }
     </style>
 </head>
 <body>
-    <div class="samePositionElements" id="testedDiv"></div>
-    <div class="samePositionElements" id="coveringDiv"></div>
+        <div class="element samePositionElements testingDiv" id="testedDiv"></div>
+        <div class="element samePositionElements coveringDiv" id="coveringDiv"></div>
+
+        <div class="element testingDiv right" id="testedDiv_tl"></div>
+        <div class="element coveringDiv left" id="coveringDiv_tl"></div>
+
+        <div class="element testingDiv left" id="testedDiv_tr"></div>
+        <div class="element coveringDiv right" id="coveringDiv_tr"></div>
+
+        <div class="element testingDiv right" id="testedDiv_bl"></div>
+        <div class="element coveringDiv left" id="coveringDiv_bl"></div>
+
+        <div class="element testingDiv left" id="testedDiv_br"></div>
+        <div class="element coveringDiv right" id="coveringDiv_br"></div>
+
+        <div class="element testingDiv" id="testedDiv_c"></div>
+        <div class="element coveringDiv" id="coveringDiv_c"></div>
+
+        <div class="element testingDiv" id="testedDiv_sbs"></div>
+        <div class="element coveringDiv" id="adjacentDiv_sbs"></div>
 </body>
 </html>
 


### PR DESCRIPTION
Adding a method to assert that an element is not being covered by another.  

This method gets the surrounding square space of an item and checks points on the item and compares them to the element being tested.  If there is an item that is found to be different, than the one specified, an exception is thrown.  

A simple test was added to assert that the assertion is working as intended.

Another pull request exists for adding this in 2.0 also [here](https://github.com/Medology/FlexibleMink/pull/199)