### PR TITLE
Creating Method to Assert Element is not Covered by Another 

### DIFF
--- a/features/FlexibleContext/assertElementIsNotCovered.feature
+++ b/features/FlexibleContext/assertElementIsNotCovered.feature
@@ -1,0 +1,13 @@
+Feature:  Assert Checkbox
+  In order to ensure that elements are interactive
+  As a developer
+  I should have assertions for elements covering others
+
+  Background:
+    Given I am on "/covering-elements.html"
+
+  Scenario: Assert element is not covered
+    When I assert that the "testedDiv" element should not be covered by another
+    Then the assertion should throw an ExpectationException
+     And the assertion should fail with the message 'An element is above an interacting element.'
+

--- a/features/FlexibleContext/assertElementIsNotCovered.feature
+++ b/features/FlexibleContext/assertElementIsNotCovered.feature
@@ -6,8 +6,23 @@ Feature:  Assert Checkbox
   Background:
     Given I am on "/covering-elements.html"
 
-  Scenario: Assert element is not covered
-    When I assert that the "testedDiv" element should not be covered by another
+  Scenario Outline: Assert Element is not covered
+    When I assert that the "<id>" element should not be covered by another
     Then the assertion should throw an ExpectationException
      And the assertion should fail with the message 'An element is above an interacting element.'
 
+    Examples:
+      | id           |
+      | testedDiv    |
+      | testedDiv_tl |
+      | testedDiv_tr |
+      | testedDiv_bl |
+      | testedDiv_br |
+
+  Scenario: Assert Calling Method on Covering Method Passes
+    When I assert that the "coveringDiv" element should not be covered by another
+    Then the assertion should pass
+
+  Scenario: Assert Uncovered Element Doesn't Throw Exception
+    When I assert that the "testedDiv_sbs" element should not be covered by another
+    Then the assertion should pass

--- a/src/Medology/Behat/Mink/FlexibleContext.php
+++ b/src/Medology/Behat/Mink/FlexibleContext.php
@@ -1427,16 +1427,15 @@ class FlexibleContext extends MinkContext
      * Keep in mind that at the moment, this method performs a check in a square area so this may not work
      * correctly with elements of different shapes.
      *
-     * @param  NodeElement              $element   The element to assert that is not covered by something else.
-     * @param  int                      $threshold Minimum resolution percentage checked.  100 will be all points, and 0 will be none.
-     *                                             Percent relative to the size of the element.
+     * @param  NodeElement              $element  The element to assert that is not covered by something else.
+     * @param  int                      $leniency Percent of leniency when performing each pixel check.
      * @throws ExpectationException     If element is found to be covered by another.
      * @throws InvalidArgumentException The threshold provided is outside of the 0-100 range accepted.
      */
-    public function assertElementIsNotCovered(NodeElement $element, $threshold = 90)
+    public function assertElementIsNotCovered(NodeElement $element, $leniency = 20)
     {
-        if ($threshold < 1 || $threshold > 100) {
-            throw new InvalidArgumentException('The threshold provided is outside of the 1-100 range accepted.');
+        if ($leniency < 0 || $leniency > 99) {
+            throw new InvalidArgumentException('The leniency provided is outside of the 0-50 range accepted.');
         }
 
         $xpath = $element->getXpath();
@@ -1448,28 +1447,31 @@ class FlexibleContext extends MinkContext
 JS
         );
 
-        $width = $coordinates['width'];
-        $height = $coordinates['height'];
+        $width = $coordinates['width'] - 1;
+        $height = $coordinates['height'] - 1;
+        $right = $coordinates['right'];
+        $bottom = $coordinates['bottom'];
 
         // X and Y are the starting points.
         $x = $coordinates['left'];
         $y = $coordinates['top'];
-        $resolution = floor($threshold * $width / 100);
+
+        $xSpacing = ($width * ($leniency / 100)) ?: 1;
+        $ySpacing = ($height * ($leniency / 100)) ?: 1;
 
         $expected = $element->getOuterHtml();
 
         /**
          * Asserts that each point checked on the row isn't covered by an element that doesn't match the expected.
          *
-         * @param  int                  $x     Starting X position.
-         * @param  int                  $y     Starting Y position.
-         * @param  int                  $width Width of element.
+         * @param  int                  $x      Starting X position.
+         * @param  int                  $y      Starting Y position.
+         * @param  int                  $xLimit Width of element.
          * @throws ExpectationException If element is found to be covered by another in the row specified.
          */
-        $assertRow = function ($x, $y, $width) use ($expected, $resolution) {
-            while ($x <= $width) {
+        $assertRow = function ($x, $y, $xLimit) use ($expected, $xSpacing) {
+            while ($x < $xLimit) {
                 $found = $this->getSession()->evaluateScript("return document.elementFromPoint($x, $y).outerHTML;");
-
                 if ($expected != $found) {
                     throw new ExpectationException(
                         'An element is above an interacting element.',
@@ -1477,14 +1479,38 @@ JS
                     );
                 }
 
-                $x += $resolution;
+                $x += $xSpacing;
             }
         };
 
         // Go through each row in the square area found.
-        while ($y <= $height) {
-            $assertRow($x, $y, $width);
-            $y += $resolution;
+        while ($y < $bottom) {
+            $assertRow($x, $y, $right);
+            $y += $ySpacing;
         }
+    }
+
+    /**
+     * Stipple drawing method for points specified on a page canvas.
+     *
+     * @param int    $x     X coordinate where to place dot.
+     * @param int    $y     Y coordinate where to place dot.
+     * @param string $color The hex color code for the color of the point being drawn.  Keep in mind, the item will
+     *                      appear semi transparent.
+     *
+     * @throws UnsupportedDriverActionException When operation not supported by the driver
+     * @throws DriverException                  When the operation cannot be done
+     */
+    protected function stipple($x, $y, $color = '#0f0')
+    {
+        $script = <<<JS
+(function () {
+        var point = document.createElement('div');
+        point.style.cssText = "position:absolute;top:{$y}px;left:{$x}px;width:1px;z-index:9999999;height:1px;" 
+            + "opacity: 0.5;background-color:$color";
+        document.body.appendChild(point);
+}());
+JS;
+        $this->getSession()->getDriver()->executeScript($script);
     }
 }

--- a/src/Medology/Behat/Mink/FlexibleContext.php
+++ b/src/Medology/Behat/Mink/FlexibleContext.php
@@ -1548,30 +1548,6 @@ JS
     }
 
     /**
-     * Stipple drawing method for points specified on a page canvas.
-     *
-     * @param int    $x     X coordinate where to place dot.
-     * @param int    $y     Y coordinate where to place dot.
-     * @param string $color The hex color code for the color of the point being drawn.  Keep in mind, the item will
-     *                      appear semi transparent.
-     *
-     * @throws UnsupportedDriverActionException When operation not supported by the driver
-     * @throws DriverException                  When the operation cannot be done
-     */
-    protected function stipple($x, $y, $color = '#0f0')
-    {
-        $script = <<<JS
-(function () {
-        var point = document.createElement('div');
-        point.style.cssText = "position:absolute;top:{$y}px;left:{$x}px;width:1px;z-index:9999999;height:1px;" 
-            + "opacity: 0.5;background-color:$color";
-        document.body.appendChild(point);
-}());
-JS;
-        $this->getSession()->getDriver()->executeScript($script);
-    }
-
-    /**
      * Asserts that the current driver is Selenium 2 in preparation for performing an action that requires it.
      *
      * @param  string                           $operation the operation that you will attempt to perform that requires

--- a/src/Medology/Behat/Mink/FlexibleContext.php
+++ b/src/Medology/Behat/Mink/FlexibleContext.php
@@ -1404,4 +1404,87 @@ class FlexibleContext extends MinkContext
 
         return $NodeElements;
     }
+
+    /**
+     * Step to assert that the specified element is not covered.
+     *
+     * @param  string               $identifier Element Id to find the element used in the assertion.
+     * @throws ExpectationException If element is found to be covered by another.
+     *
+     * @Then the :identifier element should not be covered by another
+     */
+    public function assertElementIsNotCoveredByIdStep($identifier)
+    {
+        /** @var NodeElement $element */
+        $element = $this->getSession()->getPage()->find('css', "#$identifier");
+
+        $this->assertElementIsNotCovered($element);
+    }
+
+    /**
+     * Asserts that the specified element is not covered by another element.
+     *
+     * Keep in mind that at the moment, this method performs a check in a square area so this may not work
+     * correctly with elements of different shapes.
+     *
+     * @param  NodeElement              $element   The element to assert that is not covered by something else.
+     * @param  int                      $threshold Minimum resolution percentage checked.  100 will be all points, and 0 will be none.
+     *                                             Percent relative to the size of the element.
+     * @throws ExpectationException     If element is found to be covered by another.
+     * @throws InvalidArgumentException The threshold provided is outside of the 0-100 range accepted.
+     */
+    public function assertElementIsNotCovered(NodeElement $element, $threshold = 90)
+    {
+        if ($threshold < 1 || $threshold > 100) {
+            throw new InvalidArgumentException('The threshold provided is outside of the 1-100 range accepted.');
+        }
+
+        $xpath = $element->getXpath();
+
+        /** @var array $coordinates */
+        $coordinates = $this->getSession()->evaluateScript(<<<JS
+          return document.evaluate("$xpath", document, null, XPathResult.FIRST_ORDERED_NODE_TYPE, null)
+            .singleNodeValue.getBoundingClientRect();
+JS
+        );
+
+        $width = $coordinates['width'];
+        $height = $coordinates['height'];
+
+        // X and Y are the starting points.
+        $x = $coordinates['left'];
+        $y = $coordinates['top'];
+        $resolution = floor($threshold * $width / 100);
+
+        $expected = $element->getOuterHtml();
+
+        /**
+         * Asserts that each point checked on the row isn't covered by an element that doesn't match the expected.
+         *
+         * @param  int                  $x     Starting X position.
+         * @param  int                  $y     Starting Y position.
+         * @param  int                  $width Width of element.
+         * @throws ExpectationException If element is found to be covered by another in the row specified.
+         */
+        $assertRow = function ($x, $y, $width) use ($expected, $resolution) {
+            while ($x <= $width) {
+                $found = $this->getSession()->evaluateScript("return document.elementFromPoint($x, $y).outerHTML;");
+
+                if ($expected != $found) {
+                    throw new ExpectationException(
+                        'An element is above an interacting element.',
+                        $this->getSession()
+                    );
+                }
+
+                $x += $resolution;
+            }
+        };
+
+        // Go through each row in the square area found.
+        while ($y <= $height) {
+            $assertRow($x, $y, $width);
+            $y += $resolution;
+        }
+    }
 }

--- a/web/covering-elements.html
+++ b/web/covering-elements.html
@@ -1,0 +1,31 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Assert Element is not Covered</title>
+    <style>
+        .samePositionElements {
+            position: absolute;
+            top: 0;
+            left: 0;
+            width: 150px;
+            height: 150px;
+        }
+
+        #testedDiv {
+            background-color: aquamarine;
+            z-index: 1;
+        }
+
+        #coveringDiv{
+            background-color: firebrick;
+            z-index: 999;
+        }
+    </style>
+</head>
+<body>
+    <div class="samePositionElements" id="testedDiv"></div>
+    <div class="samePositionElements" id="coveringDiv"></div>
+</body>
+</html>
+

--- a/web/covering-elements.html
+++ b/web/covering-elements.html
@@ -4,28 +4,118 @@
     <meta charset="UTF-8">
     <title>Assert Element is not Covered</title>
     <style>
-        .samePositionElements {
-            position: absolute;
-            top: 0;
-            left: 0;
-            width: 150px;
-            height: 150px;
+        .element {
+            width: 75px;
+            height: 75px;
+            position: fixed;
         }
 
-        #testedDiv {
+        .samePositionElements {
+            position: fixed;
+            top: 0;
+            left: 0;
+        }
+
+        .testingDiv {
             background-color: aquamarine;
             z-index: 1;
         }
 
-        #coveringDiv{
+        .coveringDiv{
             background-color: firebrick;
             z-index: 999;
+        }
+
+        .left {
+            left: 0px;
+        }
+
+        .right {
+            left: 32px;
+        }
+
+        /* Covering Top Left Elements */
+        #testedDiv_tl {
+            top: 135px;
+        }
+
+        #coveringDiv_tl {
+            top: 100px;
+        }
+
+        /* Covering Top Right Element */
+        #testedDiv_tr {
+            top: 300px;
+        }
+
+        #coveringDiv_tr {
+            top: 250px;
+        }
+
+        /* Covering Bottom Left */
+        #testedDiv_bl {
+            top: 400px;
+        }
+
+        #coveringDiv_bl {
+            top: 440px;
+        }
+
+        /* Covering Bottom Right */
+        #testedDiv_br {
+            top: 545px;
+        }
+
+        #coveringDiv_br {
+            top: 585px;
+        }
+
+        /* Covering Center */
+        #testedDiv_c {
+            top: 50px;
+            left: 200px;
+        }
+
+        #coveringDiv_c {
+            top: 70px;
+            left: 222px;
+
+            width: 32px;
+            height: 32px;
+        }
+
+        #testedDiv_sbs {
+            top: 70px;
+            left: 350px;
+        }
+
+        #adjacentDiv_sbs {
+            top: 70px;
+            left: 425px;
         }
     </style>
 </head>
 <body>
-    <div class="samePositionElements" id="testedDiv"></div>
-    <div class="samePositionElements" id="coveringDiv"></div>
+        <div class="element samePositionElements testingDiv" id="testedDiv"></div>
+        <div class="element samePositionElements coveringDiv" id="coveringDiv"></div>
+
+        <div class="element testingDiv right" id="testedDiv_tl"></div>
+        <div class="element coveringDiv left" id="coveringDiv_tl"></div>
+
+        <div class="element testingDiv left" id="testedDiv_tr"></div>
+        <div class="element coveringDiv right" id="coveringDiv_tr"></div>
+
+        <div class="element testingDiv right" id="testedDiv_bl"></div>
+        <div class="element coveringDiv left" id="coveringDiv_bl"></div>
+
+        <div class="element testingDiv left" id="testedDiv_br"></div>
+        <div class="element coveringDiv right" id="coveringDiv_br"></div>
+
+        <div class="element testingDiv" id="testedDiv_c"></div>
+        <div class="element coveringDiv" id="coveringDiv_c"></div>
+
+        <div class="element testingDiv" id="testedDiv_sbs"></div>
+        <div class="element coveringDiv" id="adjacentDiv_sbs"></div>
 </body>
 </html>
 


### PR DESCRIPTION
Adding a method to assert that an element is not being covered by another.

This method gets the surrounding square space of an item and checks points on the item and compares them to the element being tested. If there is an item that is found to be different, than the one specified, an exception is thrown.

A simple test was added to assert that the assertion is working as intended.

Another pull request exists for adding this in 1.0 also [here](https://github.com/Medology/FlexibleMink/pull/198)