### PR TITLE
Modifying assertElementIsNotCovered method to account for elements in the tested element

### DIFF
--- a/src/Behat/FlexibleMink/Context/FlexibleContext.php
+++ b/src/Behat/FlexibleMink/Context/FlexibleContext.php
@@ -1299,7 +1299,7 @@ JS
         $assertRow = function ($x, $y, $xLimit) use ($expected, $xSpacing) {
             while ($x < $xLimit) {
                 $found = $this->getSession()->evaluateScript("return document.elementFromPoint($x, $y).outerHTML;");
-                if ($expected != $found) {
+                if (strpos($expected, $found) === false) {
                     throw new ExpectationException(
                         'An element is above an interacting element.',
                         $this->getSession()

--- a/web/covering-elements.html
+++ b/web/covering-elements.html
@@ -114,7 +114,7 @@
         <div class="element testingDiv" id="testedDiv_c"></div>
         <div class="element coveringDiv" id="coveringDiv_c"></div>
 
-        <div class="element testingDiv" id="testedDiv_sbs"></div>
+        <div class="element testingDiv" id="testedDiv_sbs"><h1>Testing</h1></div>
         <div class="element coveringDiv" id="adjacentDiv_sbs"></div>
 </body>
 </html>


### PR DESCRIPTION
At the moment the assertElementIsNotCovered method does not account for items within the element.

If an element has a header for example, the method is at the moment failing because at that point the header is on top of the element specified.  This is usually expected to be the case, so I've modified the method to account for this and added a small header to an existing tested element.