### PR TITLE
#6996 Restore field blur that was added by #6719 [ver 1.0]

### DIFF
--- a/src/Behat/FlexibleMink/Context/FlexibleContext.php
+++ b/src/Behat/FlexibleMink/Context/FlexibleContext.php
@@ -213,6 +213,7 @@ class FlexibleContext extends MinkContext
         });
 
         $element->setValue($value);
+        $element->blur();
     }
 
     /**


### PR DESCRIPTION
For https://github.com/Medology/stdcheck.com/issues/6996

## Problem

https://github.com/Medology/stdcheck.com/issues/6719 fixed a bunch of intermittent failing tests by ensuring validation would be refreshed after filling out fields. We lost this functionality when `fillField` was removed from `WebContext`.

## Examples

https://37570-27205538-gh.circle-artifacts.com/13/tmp/stdcheck.com/artifacts/Credit_Card_Fraud_Prevention-the_braintree_response_should_be_fraud.png

https://34893-27205538-gh.circle-artifacts.com/4/tmp/stdcheck.com/artifacts/Physician_Consultation_and_Treatment_Request-I_should_see_Your_request_has_been_submitted_to_our_phy.png

## No 2.0 PR b/c `fillField` doesn't exist yet in 2.0