### PR TITLE
#6996 Restore field blur that was added by #6719 [ver 2.0]

### DIFF
--- a/bin/php
+++ b/bin/php
@@ -4,4 +4,4 @@ docker run --rm -it --env-file "$(pwd)"/docker/.env \
     -v "$(pwd)":/app -w /app \
 	--link web:dockermachine.local \
 	--net flexiblemink_default \
-	php:5.6-cli php $@
+	php:5.6-cli php "$@"

--- a/features/FlexibleContext/assertFieldVisibility.feature
+++ b/features/FlexibleContext/assertFieldVisibility.feature
@@ -1,0 +1,17 @@
+Feature:  Assert Fields visibility
+  In order to ensure that an input is visible
+  As a developer
+  I should have field visibility assertions
+
+  Background:
+    Given I am on "/assert-field-visibility.html"
+
+  Scenario: Developer Can Test an input is not visible
+    Then the field "nonVisible" should not be visible
+
+  Scenario: Developer Can Test an input is visible
+    Then the field "visible" should be visible
+
+  Scenario: Assertion fails reliably if visibility is not found
+    When  I assert that the field "nonVisible" should be visible
+    Then the assertion should throw an ExpectationException

--- a/features/TableContext.feature
+++ b/features/TableContext.feature
@@ -59,3 +59,8 @@ Feature: Table Context
      And the table "table-with-select" should have the following values:
       | Name    | Zhang |
       | Country | China |
+
+  Scenario: Developer can Test a table with a nested table within it
+    Then there should be a table on the page with the following information:
+      | Test Column                             |
+      | Testing Column with Hidden Nested Table |

--- a/src/Behat/FlexibleMink/Context/FlexibleContext.php
+++ b/src/Behat/FlexibleMink/Context/FlexibleContext.php
@@ -213,6 +213,7 @@ class FlexibleContext extends MinkContext
         });
 
         $element->setValue($value);
+        $element->blur();
     }
 
     /**

--- a/src/Behat/FlexibleMink/Context/FlexibleContext.php
+++ b/src/Behat/FlexibleMink/Context/FlexibleContext.php
@@ -129,6 +129,29 @@ class FlexibleContext extends MinkContext
 
     /**
      * {@inheritdoc}
+     * @Then /^the field "(?P<field>[^"]+)" should(?P<not> not|) be visible$/
+     */
+    public function assertFieldVisibility($field, $not)
+    {
+        $locator = $this->fixStepArgument($field);
+
+        $fields = $this->getSession()->getPage()->findAll(
+          'named',
+          ['field', $this->getSession()->getSelectorsHandler()->xpathLiteral($locator)]
+        );
+
+        if (count($fields) > 1) {
+            throw new ExpectationException("The field '$locator' was found more than one time", $this->getSession());
+        }
+
+        $shouldBeVisible = !$not;
+        if (($shouldBeVisible && !$fields[0]->isVisible()) || (!$shouldBeVisible && $fields[0]->isVisible())) {
+            throw new ExpectationException("The field '$locator' was " . (!$not ? 'not ' : '') . 'visible or not found', $this->getSession());
+        }
+    }
+
+    /**
+     * {@inheritdoc}
      */
     public function assertElementContainsText($element, $text)
     {

--- a/src/Behat/FlexibleMink/Context/StoreContext.php
+++ b/src/Behat/FlexibleMink/Context/StoreContext.php
@@ -48,7 +48,7 @@ trait StoreContext
     /**
      * {@inheritdoc}
      */
-    protected function put($thing, $key)
+    public function put($thing, $key)
     {
         $this->registry[$key][] = $thing;
     }
@@ -56,7 +56,7 @@ trait StoreContext
     /**
      * {@inheritdoc}
      */
-    protected function assertIsStored($key, $nth = null)
+    public function assertIsStored($key, $nth = null)
     {
         if (!$thing = $this->isStored($key, $nth)) {
             throw new Exception("Entry $nth for $key was not found in the store.");
@@ -86,7 +86,7 @@ trait StoreContext
     /**
      * {@inheritdoc}
      */
-    protected function get($key, $nth = null)
+    public function get($key, $nth = null)
     {
         if (!$nth) {
             list($key, $nth) = $this->parseKey($key);
@@ -102,7 +102,7 @@ trait StoreContext
     /**
      * {@inheritdoc}
      */
-    protected function getThingProperty($key, $property, $nth = null)
+    public function getThingProperty($key, $property, $nth = null)
     {
         $thing = $this->assertIsStored($key, $nth);
 
@@ -116,7 +116,7 @@ trait StoreContext
     /**
      * {@inheritdoc}
      */
-    protected function injectStoredValues($string, callable $onGetFn = null, callable $hasValue = null)
+    public function injectStoredValues($string, callable $onGetFn = null, callable $hasValue = null)
     {
         if ($onGetFn && (new ReflectionFunction($onGetFn))->getNumberOfParameters() != 1) {
             throw new Exception('Method $onGetFn must take one argument!');
@@ -168,7 +168,7 @@ trait StoreContext
     /**
      * {@inheritdoc}
      */
-    protected function isStored($key, $nth = null)
+    public function isStored($key, $nth = null)
     {
         if (!$nth) {
             list($key, $nth) = $this->parseKey($key);

--- a/src/Behat/FlexibleMink/Context/TableContext.php
+++ b/src/Behat/FlexibleMink/Context/TableContext.php
@@ -415,7 +415,7 @@ trait TableContext
             $domTables = $page->findAll('css', 'table');
             foreach ($domTables as $domTable) {
                 /** @var NodeElement[] $domRows */
-                $domRows = $domTable->findAll('css', 'tr');
+                $domRows = $domTable->findAll('xpath', '/thead/tr|tbody/tr');
 
                 if (count($domRows) != count($table)) {
                     // This table doesn't have enough rows to match us.
@@ -426,7 +426,7 @@ trait TableContext
                     $domRow = $domRows[$rowNum];
 
                     /** @var NodeElement[] $domCells */
-                    $domCells = $domRow->findAll('css', 'th, td');
+                    $domCells = $domRow->findAll('xpath', '/th|td');
 
                     if (count($domCells) != count($row)) {
                         // This table doesn't have enough columns to match us.

--- a/src/Behat/FlexibleMink/Context/TableContext.php
+++ b/src/Behat/FlexibleMink/Context/TableContext.php
@@ -406,7 +406,9 @@ trait TableContext
      */
     public function assertTableWithStructureExists(TableNode $tableNode)
     {
-        $table = $tableNode->getRows();
+        $table = array_map(function ($rowData) {
+            return array_map([$this, 'injectStoredValues'], array_values($rowData));
+        }, $tableNode->getRows());
 
         $this->waitFor(function () use ($table) {
             $page = $this->getSession()->getPage();
@@ -415,7 +417,7 @@ trait TableContext
             $domTables = $page->findAll('css', 'table');
             foreach ($domTables as $domTable) {
                 /** @var NodeElement[] $domRows */
-                $domRows = $domTable->findAll('xpath', '/thead/tr|tbody/tr');
+                $domRows = $domTable->findAll('xpath', '/tfoot/tr|thead/tr|tbody/tr');
 
                 if (count($domRows) != count($table)) {
                     // This table doesn't have enough rows to match us.

--- a/src/Behat/FlexibleMink/PseudoInterface/FlexibleContextInterface.php
+++ b/src/Behat/FlexibleMink/PseudoInterface/FlexibleContextInterface.php
@@ -45,6 +45,15 @@ trait FlexibleContextInterface
     abstract public function assertPageAddress($page);
 
     /**
+     * Asserts that a field is visible or not.
+     *
+     * @param  string               $field The field to be checked
+     * @param  bool                 $not   check if field should be visible or not.
+     * @throws ExpectationException
+     */
+    abstract public function assertFieldVisibility($field, $not);
+
+    /**
      * This method overrides the MinkContext::assertPageContainsText() default behavior for assertFieldContains to
      * ensure that it waits for the text to be available with a max time limit.
      *

--- a/src/Behat/FlexibleMink/PseudoInterface/StoreContextInterface.php
+++ b/src/Behat/FlexibleMink/PseudoInterface/StoreContextInterface.php
@@ -27,7 +27,7 @@ trait StoreContextInterface
      * @param  int    $nth The nth value of the key.
      * @return mixed  The thing from the store.
      */
-    abstract protected function assertIsStored($key, $nth = null);
+    abstract public function assertIsStored($key, $nth = null);
 
     /**
      * Retrieves the thing stored under the specified key on the nth position in the registry.
@@ -36,7 +36,7 @@ trait StoreContextInterface
      * @param  int    $nth The nth value for the thing to retrieve.
      * @return mixed  The thing that was retrieved.
      */
-    abstract protected function get($key, $nth = null);
+    abstract public function get($key, $nth = null);
 
     /**
      * Gets the value of a property from an object of the store.
@@ -48,7 +48,7 @@ trait StoreContextInterface
      * @throws Exception If the object does not have the specified property.
      * @return mixed     The value of the property.
      */
-    abstract protected function getThingProperty($key, $property, $nth = null);
+    abstract public function getThingProperty($key, $property, $nth = null);
 
     /**
      * Parses the string for references to stored items and replaces them with the value from the store.
@@ -68,7 +68,7 @@ trait StoreContextInterface
      * @throws Exception If the string references something that does not exist in the store.
      * @return string    The parsed string.
      */
-    abstract protected function injectStoredValues($string, callable $onGetFn = null, callable $hasValue = null);
+    abstract public function injectStoredValues($string, callable $onGetFn = null, callable $hasValue = null);
 
     /**
      * Checks that the specified thing exists in the registry.
@@ -77,7 +77,7 @@ trait StoreContextInterface
      * @param  int    $nth The nth value of the key.
      * @return bool   True if the thing exists, false if not.
      */
-    abstract protected function isStored($key, $nth = null);
+    abstract public function isStored($key, $nth = null);
 
     /**
      * Stores the specified thing under the specified key in the registry.
@@ -85,7 +85,7 @@ trait StoreContextInterface
      * @param mixed  $thing The thing to be stored.
      * @param string $key   The key to store the thing under.
      */
-    abstract protected function put($thing, $key);
+    abstract public function put($thing, $key);
 
     /**
      * Adds a reference to a stored thing under the new specified key.

--- a/web/assert-field-visibility.html
+++ b/web/assert-field-visibility.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Assert Field Visibility</title>
+</head>
+<body>
+<form>
+    <h1>Assert Field Visibility</h1>
+    <div>Non Visible Field</div>
+    <div style="display:none;">
+        <input
+                type="number"
+                id="nonVisible"
+                name="nonVisible"
+                class="input-group-field with-no-margin"
+                required/>
+    </div>
+    <div>Visible Field</div>
+    <div>
+        <input
+                type="number"
+                id="visible"
+                name="visible"
+                required/>
+    </div>
+</form>
+</body>
+</html>
+

--- a/web/table.html
+++ b/web/table.html
@@ -171,6 +171,33 @@
       </tr>
     </tbody>
   </table>
+
+<table id="table-with-nested-table">
+  <thead>
+    <tr>
+      <th>Test Column</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>
+        Testing Column with Hidden Nested Table
+        <table style="visibility: hidden;">
+          <thead>
+            <tr>
+              <th>Random Header</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>Random Content</td>
+            </tr>
+          </tbody>
+        </table>
+      </td>
+    </tr>
+  </tbody>
+</table>
 </body>
 
 </html>


### PR DESCRIPTION
For https://github.com/Medology/stdcheck.com/issues/6996

## Problem

https://github.com/Medology/stdcheck.com/issues/6719 fixed a bunch of intermittent failing tests by ensuring validation would be refreshed after filling out fields. We lost this functionality when `fillField` was removed from `WebContext`.

## Examples

https://37570-27205538-gh.circle-artifacts.com/13/tmp/stdcheck.com/artifacts/Credit_Card_Fraud_Prevention-the_braintree_response_should_be_fraud.png

https://34893-27205538-gh.circle-artifacts.com/4/tmp/stdcheck.com/artifacts/Physician_Consultation_and_Treatment_Request-I_should_see_Your_request_has_been_submitted_to_our_phy.png

Identical to https://github.com/Medology/FlexibleMink/pull/212