### PR TITLE
[1.0] Fix viewport visibility checks not working on scrolled pages

### DIFF
--- a/features/FlexibleContext/assertElementIsDisplayed.feature
+++ b/features/FlexibleContext/assertElementIsDisplayed.feature
@@ -28,6 +28,12 @@ Feature: Assert an element is displayed or not displayed
     And "Invisible 2" should not be visible in the viewport
     And "Visible 2" should not be visible in the viewport
 
+  Scenario: Visibility works on scrolled pages
+    Given I am on "/big-page.html"
+     When I scroll to the bottom of the page
+     Then "the almost-last div" should be fully visible in the viewport
+     Then "the last div" should be partially visible in the viewport
+
   Scenario Outline: Throw a ExpectationException when visibility test fails
     When I assert that <Step Text to Assert>
     Then the assertion should throw a ExpectationException

--- a/src/Behat/FlexibleMink/Context/FlexibleContext.php
+++ b/src/Behat/FlexibleMink/Context/FlexibleContext.php
@@ -1080,7 +1080,7 @@ class FlexibleContext extends MinkContext
     {
         $driver = $this->assertSelenium2Driver('Checks if a node Element is fully visible in the viewport.');
         if (!$driver->isDisplayed($element->getXpath()) ||
-            count(($parents = $this->getListOfAllNodeElementParents($element, 'html'))) < 1
+            count(($parents = $this->getListOfAllNodeElementParents($element, 'body'))) < 1
         ) {
             return false;
         }
@@ -1107,7 +1107,7 @@ class FlexibleContext extends MinkContext
     public function nodeIsVisibleInViewport(NodeElement $element)
     {
         $driver = $this->assertSelenium2Driver('Checks if a node Element is visible in the viewport.');
-        $parents = $this->getListOfAllNodeElementParents($element, 'html');
+        $parents = $this->getListOfAllNodeElementParents($element, 'body');
 
         if (!$driver->isDisplayed($element->getXpath()) || count($parents) < 1) {
             return false;

--- a/web/big-page.html
+++ b/web/big-page.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Scrollable Divs</title>
+    <style>
+        div.top {
+            height:5000px;
+        }
+        div.bottom {
+            height:200px;
+            transform: translate(0, 20px);
+        }
+    </style>
+</head>
+<body>
+<div class="top">Scroll down.</div>
+<div class="bottom" data-qa-id="the almost-last div">Hello!</div>
+<div class="bottom" data-qa-id="the last div">Hello!</div>
+</body>
+</html>


### PR DESCRIPTION
`Then :element should be fully/partially visible in the viewport` does not work when the page is scrolled, since the `<html>` element's reported viewport bounding rectangle is always sized to screen dimensions and snapped to the top-left of the page, regardless of its size in the element inspector. This issue appears to be unique to the `<html>` tag in particular, so this PR excludes that from the viewport checks.

I'll open a similar PR for the 2.0 branch once this is approved and merged, to avoid having overlapping reviews if both were to be reviewed simultaneously.