### PR TITLE
Fix assertJavascriptVariables calls injectStoredValues on wrong object

### DIFF
--- a/src/Medology/Behat/Mink/JavaScriptContext.php
+++ b/src/Medology/Behat/Mink/JavaScriptContext.php
@@ -5,6 +5,7 @@ namespace Medology\Behat\Mink;
 use Behat\Behat\Context\Context;
 use Behat\Gherkin\Node\TableNode;
 use Behat\Mink\Exception\ExpectationException;
+use Medology\Behat\UsesStoreContext;
 
 /**
  * Provides functionality modifying and checking the Javascript environment in the browser.
@@ -12,6 +13,7 @@ use Behat\Mink\Exception\ExpectationException;
 class JavaScriptContext implements Context
 {
     use UsesFlexibleContext;
+    use UsesStoreContext;
 
     /**
      * Determines if a javascript variable is set and has a value.
@@ -140,7 +142,7 @@ class JavaScriptContext implements Context
      */
     public function assertJavascriptVariables(TableNode $table)
     {
-        $attributes = array_map([$this, 'injectStoredValues'], $table->getRowsHash());
+        $attributes = array_map([$this->storeContext, 'injectStoredValues'], $table->getRowsHash());
 
         foreach ($attributes as $key => $value) {
             $this->assertJavascriptVariable($key, $value);


### PR DESCRIPTION
For https://github.com/medology/stdcheck.com/issues/6717

## Steps:
Invoke assertJavascriptVariables on an instance of JavaScriptContext with valid parameters

## Expected Behavior:
The method should assert that the provided javascript variables exist with the specified values.

## Actual Behavior:
An error occurs stating that a non-existent method "injectStoredValues" is called.

## Cause:
assertJavascriptVariables() is calling injectStoredValues() on "this" but the method exists on a different class.

## Fix:
Added the UsesStoreContext trait and modified assertJavascriptVariables() to call injectStoredValues() on "this->storeContext"