### PR TITLE
Allow registration of Store initialization lambdas

### DIFF
--- a/src/Medology/Behat/StoreContext.php
+++ b/src/Medology/Behat/StoreContext.php
@@ -23,6 +23,9 @@ class StoreContext extends Store implements Context
     /** @var Assert */
     protected $assert;
 
+    /** @var callable[] array of functions to call after the registry is cleared to initialize it for use */
+    protected $initializations;
+
     /** @var Key the key service for the noun-store */
     protected $key;
 
@@ -31,6 +34,7 @@ class StoreContext extends Store implements Context
         parent::__construct();
 
         $this->assert = new Assert($this);
+        $this->initializations = [];
         $this->key = Key::getInstance();
     }
 
@@ -58,9 +62,19 @@ class StoreContext extends Store implements Context
     {
         $this->reset();
 
-        if (method_exists($this, 'onStoreInitialized')) {
-            $this->onStoreInitialized();
+        foreach ($this->initializations as $callable) {
+            $callable($this);
         }
+    }
+
+    /**
+     * Registers an initialization lambda to be called after the registry is cleared before each scenario.
+     *
+     * @param callable $callable must accept a single argument, which is the StoreContext
+     */
+    public function registerInitialization(callable $callable)
+    {
+        $this->initializations[] = $callable;
     }
 
     /**


### PR DESCRIPTION
## Problem:
When the StoreContext was a trait in FlexibleMink 1.0, it used a method_exists() check to determine if there was a onStoreInitialized() method, and called it if so. This was used by consumers to register certain nouns that should be available to all tests in the suite, such as "Browser" which would provide the IP Address etc of the client's browser. Since the StoreContext is no longer a trait, this method does not work.

## Fix:
I replaced the method_exists() check with a registerInitialization() method that the consumer can pass a lambda to. The lambda will be called immediately after the store is reset between each test scenario, allowing the store to be seeded or modified as necessary.