### PR TITLE
referToStoredAs() now supports Given

### DIFF
--- a/src/Medology/Behat/StoreContext.php
+++ b/src/Medology/Behat/StoreContext.php
@@ -334,7 +334,7 @@ class StoreContext extends Store implements Context
 
     /**
      * Adds a reference to a stored thing under the new specified key.
-     *
+     * @Given /^(?:the |)"(?P<current>[^"]*)" has an alias of "(?P<new>[^"]*)"$/
      * @When  /^(?:I |)refer to (?:the |)"(?P<current>[^"]*)" as "(?P<new>[^"]*)"$/
      * @param string $current The current key of the thing.
      * @param string $new     The new key under which to store the thing.


### PR DESCRIPTION
## Problem:
The referToStoredAs() method on the StoreContext is being used by many clients as a "Given" step. Since the step is only implemented as a "When", this usage breaks when strict keyword enforcement is used.

## Fix:
Since it is fine to use both a "Given" and a "When" on the same Behat Step Definition (as long as the step carries out the task exactly as a user would and does not take shortcuts), I simply added a "Given" variation of the step pattern to the definition.