### PR TITLE
referToStoredAs() now supports Given

### DIFF
--- a/src/Behat/FlexibleMink/Context/StoreContext.php
+++ b/src/Behat/FlexibleMink/Context/StoreContext.php
@@ -343,6 +343,7 @@ trait StoreContext
     /**
      * {@inheritdoc}
      *
+     * @Given /^(?:the |)"(?P<current>[^"]*)" has an alias of "(?P<new>[^"]*)"$/
      * @When /^(?:I |)refer to (?:the |)"(?P<current>[^"]*)" as "(?P<new>[^"]*)"$/
      */
     public function referToStoredAs($current, $new)


### PR DESCRIPTION
## Problem:
The referToStoredAs() method on the StoreContext is being used by many clients as a "Given" step. Since the step is only implemented as a "When", this usage breaks when strict keyword enforcement is used.

## Fix:
Since it is fine to use both a "Given" and a "When" on the same Behat Step Definition (as long as the step carries out the task exactly as a user would and does not take shortcuts), I simply added a "Given" variation of the step pattern to the definition.