### PR TITLE
Wrap assertFieldExists in a spinner

### DIFF
--- a/features/FlexibleContext/assertFieldExists.feature
+++ b/features/FlexibleContext/assertFieldExists.feature
@@ -32,6 +32,10 @@ Feature:  Assert Fields exists
     Then the assertion should throw an ExpectationException
      And the assertion should fail with the message "No visible input found for 'Sushi'"
 
+  Scenario: Field assertions should retry before failing
+     Then I should see the following fields:
+        | Ice Cream |
+
   Scenario: Developer Can Test for option with varying input/label setup
     Then I should see the following fields:
        | Pizza     |

--- a/src/Behat/FlexibleMink/Context/FlexibleContext.php
+++ b/src/Behat/FlexibleMink/Context/FlexibleContext.php
@@ -548,7 +548,7 @@ class FlexibleContext extends MinkContext
     {
         $context = $context ?: $this->getSession()->getPage();
 
-        $this->waitFor(function () use ($fieldName, $context) {
+        return $this->waitFor(function () use ($fieldName, $context) {
             /** @var NodeElement[] $fields */
             $fields = ($context->findAll('named', ['field', $fieldName]) ?:
                 $this->getInputsByLabel($fieldName, $context));

--- a/src/Behat/FlexibleMink/Context/FlexibleContext.php
+++ b/src/Behat/FlexibleMink/Context/FlexibleContext.php
@@ -548,16 +548,19 @@ class FlexibleContext extends MinkContext
     {
         $context = $context ?: $this->getSession()->getPage();
 
-        /** @var NodeElement[] $fields */
-        $fields = ($context->findAll('named', ['field', $fieldName]) ?: $this->getInputsByLabel($fieldName, $context));
+        $this->waitFor(function () use ($fieldName, $context) {
+            /** @var NodeElement[] $fields */
+            $fields = ($context->findAll('named', ['field', $fieldName]) ?:
+                $this->getInputsByLabel($fieldName, $context));
 
-        foreach ($fields as $field) {
-            if ($field->isVisible()) {
-                return $field;
+            foreach ($fields as $field) {
+                if ($field->isVisible()) {
+                    return $field;
+                }
             }
-        }
 
-        throw new ExpectationException("No visible input found for '$fieldName'", $this->getSession());
+            throw new ExpectationException("No visible input found for '$fieldName'", $this->getSession());
+        });
     }
 
     /**

--- a/web/assert-field-exists.html
+++ b/web/assert-field-exists.html
@@ -33,6 +33,12 @@
         <input type="checkbox" name="favoriteFood" value="Hot Dog" id="Hot Dog"> <label for="Hot Dog">Hot Dog</label>
         <input type="checkbox" name="favoriteFood" value="Chocolate" id="Chocolate">
             <label for="Chocolate">Chocolate</label>
+
+        <label class="hidden shows-eventually">
+            <input type="checkbox" name="favoriteFood" value="Ice Cream" id="icecream">
+            Ice Cream
+        </label>
+
         <label class="hidden"><input type="checkbox" name="favoriteFood" value="Kale Salad"> Kale Salad</label>
         <label for="invisibleInput">Text Input:</label><input class="hidden" name="invisibleInput" type="text">
         <label for="visibleInput">Text Input:</label><input name="visibleInput" type="text">
@@ -61,6 +67,14 @@
         document.getElementById('foodSelected').innerText = 'Selected: ' + foods.join(', ');
         document.getElementById('textEntered').innerText = text.join(', ');
     }
+
+    window.setTimeout(function() {
+        var show = document.getElementsByClassName('shows-eventually');
+
+        for (var i = 0; i < show.length; i++) {
+            show[i].style.display = 'block';
+        }
+    }, 4000);
 </script>
 </body>
 </html>


### PR DESCRIPTION
Allows test scenarios that don't immediately update the page to the expected state to pass as long as the state changes within an allotted timeout.