### PR TITLE
Allow store keys to be camel cased.

### DIFF
--- a/features/StoreContext.feature
+++ b/features/StoreContext.feature
@@ -62,16 +62,16 @@ Feature: Store Context
     Given the following is stored as "Commission":
       | commissionId | commission-1234 |
       | orderId      | order-4321 |
-    Then the "'commissionId'" of the "Commission" should contain "commission-1234"
-     And the "'orderId'" of the "Commission" should contain "order-4321"
+     Then the "'commissionId'" of the "Commission" should contain "commission-1234"
+      And the "'orderId'" of the "Commission" should contain "order-4321"
 
   Scenario: Keys wrapped in single quotes that don't exist should throw an exception
     Given the following is stored as "Commission":
       | commissionId | commission-1234 |
       | orderId      | order-4321 |
-    When I assert that the "'commissionId'" of the "Commission" should contain "commission-4321"
-    Then the assertion should throw an Exception
-     And the assertion should fail with the message "Expected the 'commissionId' of the 'Commission' to contain 'commission-4321', but found 'commission-1234' instead"
-    When I assert that the "'orderId'" of the "Commission" should contain "order-1234"
-    Then the assertion should throw an Exception
-     And the assertion should fail with the message "Expected the 'orderId' of the 'Commission' to contain 'order-1234', but found 'order-4321' instead"
+     When I assert that the "'commissionId'" of the "Commission" should contain "commission-4321"
+     Then the assertion should throw an Exception
+      And the assertion should fail with the message "Expected the 'commissionId' of the 'Commission' to contain 'commission-4321', but found 'commission-1234' instead"
+     When I assert that the "'orderId'" of the "Commission" should contain "order-1234"
+     Then the assertion should throw an Exception
+      And the assertion should fail with the message "Expected the 'orderId' of the 'Commission' to contain 'order-1234', but found 'order-4321' instead"

--- a/features/StoreContext.feature
+++ b/features/StoreContext.feature
@@ -57,3 +57,21 @@ Feature: Store Context
      When I assert that the "body" of the "Slogan" should contain "candy"
      Then the assertion should throw an Exception
       And the assertion should fail with the message "Expected the 'body' of the 'Slogan' to contain 'candy', but found 'Eat more cake' instead"
+
+  Scenario: Keys wrapped in single quote should not be converted to snake case.
+    Given the following is stored as "Commission":
+      | commissionId | commission-1234 |
+      | orderId      | order-4321 |
+    Then the "'commissionId'" of the "Commission" should contain "commission-1234"
+     And the "'orderId'" of the "Commission" should contain "order-4321"
+
+  Scenario: Keys wrapped in single quotes that don't exist should throw an exception
+    Given the following is stored as "Commission":
+      | commissionId | commission-1234 |
+      | orderId      | order-4321 |
+    When I assert that the "'commissionId'" of the "Commission" should contain "commission-4321"
+    Then the assertion should throw an Exception
+     And the assertion should fail with the message "Expected the 'commissionId' of the 'Commission' to contain 'commission-4321', but found 'commission-1234' instead"
+    When I assert that the "'orderId'" of the "Commission" should contain "order-1234"
+    Then the assertion should throw an Exception
+     And the assertion should fail with the message "Expected the 'orderId' of the 'Commission' to contain 'order-1234', but found 'order-4321' instead"

--- a/src/Behat/FlexibleMink/Context/StoreContext.php
+++ b/src/Behat/FlexibleMink/Context/StoreContext.php
@@ -163,7 +163,7 @@ trait StoreContext
         preg_match_all('/\(the ([^\)]+) of the ([^\)]+?)( formatted as ([^\)]+))?\)/', $string, $matches);
         foreach ($matches[0] as $i => $match) {
             $thingName = $matches[2][$i];
-            $thingProperty = str_replace(' ', '_', strtolower($matches[1][$i]));
+            $thingProperty = $this->parseProperty($matches[1][$i]);
             $thingFormat = $matches[4][$i];
 
             if (!$this->isStored($thingName)) {
@@ -195,6 +195,24 @@ trait StoreContext
         }
 
         return $string;
+    }
+
+    /**
+     * Converts the property name used for reference to the actual key name.
+     *
+     * @param  string $property The property name used to reference the key.
+     * @return string
+     */
+    protected function parseProperty($property)
+    {
+        if (
+            substr($property, 0, 1) === "'" &&
+            substr($property, -1) === "'"
+        ) {
+            return trim($property, "'");
+        }
+
+        return str_replace(' ', '_', strtolower($property));
     }
 
     /**

--- a/src/Behat/FlexibleMink/Context/StoreContext.php
+++ b/src/Behat/FlexibleMink/Context/StoreContext.php
@@ -205,10 +205,7 @@ trait StoreContext
      */
     protected function parseProperty($property)
     {
-        if (
-            substr($property, 0, 1) === "'" &&
-            substr($property, -1) === "'"
-        ) {
+        if (substr($property, 0, 1) === "'" && substr($property, -1) === "'") {
             return trim($property, "'");
         }
 


### PR DESCRIPTION
This PR allows up to use single quotes around a property to exclude it from being snake cased in the case we may not have an eloquent model in the store.