### PR TITLE
Upgraded composer to v1.8.

### DIFF
--- a/bin/composer
+++ b/bin/composer
@@ -1,3 +1,3 @@
 #!/bin/bash +x
 
-docker run --rm --env-file "$(pwd)"/docker/.env -v "$(pwd)":/data -w /data composer/composer:1.2 $@
+docker run --rm --env-file "$(pwd)"/docker/.env -v "$(pwd)":/data -w /data composer:1.8 $@


### PR DESCRIPTION
composer v1.2.4 was released on 6 December 2016.

This patch upgrades it to the latest v1.8, last released on 11 February 2019.
It is still compatible with PHP 5.6.