### PR TITLE
[v2.0] Upgraded composer to v1.8.

### DIFF
--- a/bin/composer
+++ b/bin/composer
@@ -10,4 +10,4 @@ docker run \
     --rm \
     -v "$(pwd)":/data -w /data \
 	--net ${PROJECT_NAME}_default \
-	composer/composer:1.2 "$@"
+	composer:1.8 "$@"


### PR DESCRIPTION
composer v1.2.4 was released on 6 December 2016.

This patch upgrades it to the latest v1.8, last released on 11 February 2019.
It is still compatible with PHP 5.6.

For #243