### PR TITLE
 Add Assert Elements Exist & Nth Element Exist Steps

### DIFF
--- a/.idea/php.xml
+++ b/.idea/php.xml
@@ -12,7 +12,6 @@
       <path value="$PROJECT_DIR$/vendor/symfony/yaml" />
       <path value="$PROJECT_DIR$/vendor/symfony/dependency-injection" />
       <path value="$PROJECT_DIR$/vendor/symfony/console" />
-      <path value="$PROJECT_DIR$/vendor/symfony/polyfill-apcu" />
       <path value="$PROJECT_DIR$/vendor/phpunit/phpunit" />
       <path value="$PROJECT_DIR$/vendor/symfony/css-selector" />
       <path value="$PROJECT_DIR$/vendor/symfony/event-dispatcher" />
@@ -40,6 +39,12 @@
       <path value="$PROJECT_DIR$/vendor/phpdocumentor/reflection-docblock" />
       <path value="$PROJECT_DIR$/vendor/instaclick/php-webdriver" />
       <path value="$PROJECT_DIR$/vendor/sebastian/version" />
+      <path value="$PROJECT_DIR$/vendor/webmozart/assert" />
+      <path value="$PROJECT_DIR$/vendor/container-interop/container-interop" />
+      <path value="$PROJECT_DIR$/vendor/psr/container" />
+      <path value="$PROJECT_DIR$/vendor/phpdocumentor/type-resolver" />
+      <path value="$PROJECT_DIR$/vendor/phpdocumentor/reflection-common" />
+      <path value="$PROJECT_DIR$/vendor/symfony/polyfill-ctype" />
     </include_path>
   </component>
   <component name="PhpUnit">

--- a/.idea/php.xml
+++ b/.idea/php.xml
@@ -1,4 +1,50 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
-  <component name="PhpProjectSharedConfiguration" php_language_level="5.4.0" />
+  <component name="PhpIncludePathManager">
+    <include_path>
+      <path value="$PROJECT_DIR$/vendor/symfony/config" />
+      <path value="$PROJECT_DIR$/vendor/symfony/class-loader" />
+      <path value="$PROJECT_DIR$/vendor/symfony/polyfill-mbstring" />
+      <path value="$PROJECT_DIR$/vendor/symfony/translation" />
+      <path value="$PROJECT_DIR$/vendor/sebastian/comparator" />
+      <path value="$PROJECT_DIR$/vendor/sebastian/global-state" />
+      <path value="$PROJECT_DIR$/vendor/doctrine/instantiator" />
+      <path value="$PROJECT_DIR$/vendor/symfony/yaml" />
+      <path value="$PROJECT_DIR$/vendor/symfony/dependency-injection" />
+      <path value="$PROJECT_DIR$/vendor/symfony/console" />
+      <path value="$PROJECT_DIR$/vendor/symfony/polyfill-apcu" />
+      <path value="$PROJECT_DIR$/vendor/phpunit/phpunit" />
+      <path value="$PROJECT_DIR$/vendor/symfony/css-selector" />
+      <path value="$PROJECT_DIR$/vendor/symfony/event-dispatcher" />
+      <path value="$PROJECT_DIR$/vendor/symfony/filesystem" />
+      <path value="$PROJECT_DIR$/vendor/symfony/debug" />
+      <path value="$PROJECT_DIR$/vendor/phpunit/php-file-iterator" />
+      <path value="$PROJECT_DIR$/vendor/phpunit/php-timer" />
+      <path value="$PROJECT_DIR$/vendor/phpspec/prophecy" />
+      <path value="$PROJECT_DIR$/vendor/behat/behat" />
+      <path value="$PROJECT_DIR$/vendor/phpunit/php-code-coverage" />
+      <path value="$PROJECT_DIR$/vendor/phpunit/phpunit-mock-objects" />
+      <path value="$PROJECT_DIR$/vendor/phpunit/php-token-stream" />
+      <path value="$PROJECT_DIR$/vendor/phpunit/php-text-template" />
+      <path value="$PROJECT_DIR$/vendor/behat/mink-extension" />
+      <path value="$PROJECT_DIR$/vendor/psr/log" />
+      <path value="$PROJECT_DIR$/vendor/behat/gherkin" />
+      <path value="$PROJECT_DIR$/vendor/behat/mink" />
+      <path value="$PROJECT_DIR$/vendor/behat/mink-selenium2-driver" />
+      <path value="$PROJECT_DIR$/vendor/behat/transliterator" />
+      <path value="$PROJECT_DIR$/vendor/composer" />
+      <path value="$PROJECT_DIR$/vendor/sebastian/diff" />
+      <path value="$PROJECT_DIR$/vendor/sebastian/recursion-context" />
+      <path value="$PROJECT_DIR$/vendor/sebastian/exporter" />
+      <path value="$PROJECT_DIR$/vendor/sebastian/environment" />
+      <path value="$PROJECT_DIR$/vendor/phpdocumentor/reflection-docblock" />
+      <path value="$PROJECT_DIR$/vendor/instaclick/php-webdriver" />
+      <path value="$PROJECT_DIR$/vendor/sebastian/version" />
+    </include_path>
+  </component>
+  <component name="PhpUnit">
+    <phpunit_settings>
+      <PhpUnitSettings load_method="CUSTOM_LOADER" custom_loader_path="$PROJECT_DIR$/vendor/autoload.php" />
+    </phpunit_settings>
+  </component>
 </project>

--- a/composer.json
+++ b/composer.json
@@ -30,6 +30,11 @@
       "features\\": ""
     }
   },
+  "autoload-dev": {
+    "psr-4": {
+      "Tests\\": "tests/"
+    }
+  },
   "repositories": [
     {
       "type": "vcs",

--- a/src/Behat/FlexibleMink/Context/FlexibleContext.php
+++ b/src/Behat/FlexibleMink/Context/FlexibleContext.php
@@ -254,13 +254,13 @@ class FlexibleContext extends MinkContext
     /**
      * {@inheritdoc}
      */
-    public function assertElementsExist($element, $selectorType = 'css')
+    public function assertElementsExist($elementsSelector, $selectorType = 'css')
     {
         $session = $this->getSession();
 
-        return $this->waitFor(function () use ($session, $selectorType, $element) {
-            if (!$allElements = $session->getPage()->findAll($selectorType, $element)) {
-                throw new ExpectationException("No '$element' was not found", $session);
+        return $this->waitFor(function () use ($session, $selectorType, $elementsSelector) {
+            if (!$allElements = $session->getPage()->findAll($selectorType, $elementsSelector)) {
+                throw new ExpectationException("No '$elementsSelector' was not found", $session);
             }
 
             return $allElements;
@@ -270,12 +270,12 @@ class FlexibleContext extends MinkContext
     /**
      * {@inheritdoc}
      */
-    public function assertNthElement($element, $nth, $selectorType = 'css')
+    public function assertNthElement($elementSelector, $nth, $selectorType = 'css')
     {
-        $allElements = $this->assertElementsExist($element, $selectorType);
+        $allElements = $this->assertElementsExist($elementSelector, $selectorType);
 
         if (!isset($allElements[$nth - 1])) {
-            throw new ExpectationException("Element $element $nth was not found", $this->getSession());
+            throw new ExpectationException("Element $elementSelector $nth was not found", $this->getSession());
         }
 
         return $allElements[$nth - 1];

--- a/src/Behat/FlexibleMink/Context/FlexibleContext.php
+++ b/src/Behat/FlexibleMink/Context/FlexibleContext.php
@@ -253,6 +253,35 @@ class FlexibleContext extends MinkContext
 
     /**
      * {@inheritdoc}
+     */
+    public function assertElementsExist($element, $selectorType = 'css')
+    {
+        return $this->waitFor(function () use ($selectorType, $element) {
+            $session = $this->getSession();
+            if (!$allElements = $session->getPage()->findAll($selectorType, $element)) {
+                throw new ExpectationException("No '$element' was not found", $session);
+            }
+
+            return $allElements;
+        });
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function assertNthElement($element, $nth, $selectorType = 'css')
+    {
+        $allElements = $this->assertElementsExist($element, $selectorType);
+
+        if (!isset($allElements[$nth - 1])) {
+            throw new ExpectationException("Element $element $nth was not found", $this->getSession());
+        }
+
+        return $allElements[$nth - 1];
+    }
+
+    /**
+     * {@inheritdoc}
      *
      * Overrides the base method to wait for the assertion to pass, and store
      * the resulting element in the store under "element".

--- a/src/Behat/FlexibleMink/Context/FlexibleContext.php
+++ b/src/Behat/FlexibleMink/Context/FlexibleContext.php
@@ -256,8 +256,9 @@ class FlexibleContext extends MinkContext
      */
     public function assertElementsExist($element, $selectorType = 'css')
     {
-        return $this->waitFor(function () use ($selectorType, $element) {
-            $session = $this->getSession();
+        $session = $this->getSession();
+
+        return $this->waitFor(function () use ($session, $selectorType, $element) {
             if (!$allElements = $session->getPage()->findAll($selectorType, $element)) {
                 throw new ExpectationException("No '$element' was not found", $session);
             }

--- a/src/Behat/FlexibleMink/PseudoInterface/FlexibleContextInterface.php
+++ b/src/Behat/FlexibleMink/PseudoInterface/FlexibleContextInterface.php
@@ -103,6 +103,26 @@ trait FlexibleContextInterface
     abstract public function assertElementContainsText($element, $text);
 
     /**
+     * Checks that elements with specified selector exist.
+     *
+     * @param  string        $element      The element to search from.
+     * @param  string|array  $selectorType selector type locator.
+     * @return NodeElement[] All elements found with by the given selector.
+     */
+    abstract public function assertElementsExist($element, $selectorType = 'css');
+
+    /**
+     * Checks that the nth element exists and returns it.
+     *
+     * @param  string               $element      The elements to search from.
+     * @param  int                  $nth          This is the nth amount of the element.
+     * @param  string|array         $selectorType selector type locator.
+     * @throws ExpectationException
+     * @return NodeElement          The nth element found.
+     */
+    abstract public function assertNthElement($element, $nth, $selectorType = 'css');
+
+    /**
      * Checks, that element with specified CSS doesn't contain specified text.
      *
      * @see MinkContext::assertElementNotContainsText

--- a/src/Behat/FlexibleMink/PseudoInterface/FlexibleContextInterface.php
+++ b/src/Behat/FlexibleMink/PseudoInterface/FlexibleContextInterface.php
@@ -105,22 +105,23 @@ trait FlexibleContextInterface
     /**
      * Checks that elements with specified selector exist.
      *
-     * @param  string        $element      The element to search from.
-     * @param  string|array  $selectorType selector type locator.
-     * @return NodeElement[] All elements found with by the given selector.
+     * @param  string               $elementsSelector The element to search from.
+     * @param  string|array         $selectorType     selector type locator.
+     * @throws ExpectationException When no element is found.
+     * @return NodeElement[]        All elements found with by the given selector.
      */
-    abstract public function assertElementsExist($element, $selectorType = 'css');
+    abstract public function assertElementsExist($elementsSelector, $selectorType = 'css');
 
     /**
      * Checks that the nth element exists and returns it.
      *
-     * @param  string               $element      The elements to search from.
-     * @param  int                  $nth          This is the nth amount of the element.
-     * @param  string|array         $selectorType selector type locator.
-     * @throws ExpectationException
+     * @param  string               $elementSelector The elements to search from.
+     * @param  int                  $nth             This is the nth amount of the element.
+     * @param  string|array         $selectorType    selector type locator.
+     * @throws ExpectationException When there is no Nth element found
      * @return NodeElement          The nth element found.
      */
-    abstract public function assertNthElement($element, $nth, $selectorType = 'css');
+    abstract public function assertNthElement($elementSelector, $nth, $selectorType = 'css');
 
     /**
      * Checks, that element with specified CSS doesn't contain specified text.

--- a/tests/Behat/FlexibleMink/Context/FlexibleContext/AssertElementsExistTest.php
+++ b/tests/Behat/FlexibleMink/Context/FlexibleContext/AssertElementsExistTest.php
@@ -1,0 +1,32 @@
+<?php namespace Tests\Behat\FlexibleMink\Context\FlexibleContext;
+
+use Behat\Mink\Exception\ExpectationException;
+
+/**
+ * @covers \Behat\FlexibleMink\Context\FlexibleContext::assertElementsExist()
+ */
+class AssertElementsExistTest extends FlexibleContextTest
+{
+    public function testThrowsExpectationExceptionWhenElementDoesntExist()
+    {
+        $this->pageMock->method('findAll')->willReturn([]);
+        $this->setExpectedException(ExpectationException::class, "No 'image' was not found");
+        $this->flexible_context->assertElementsExist('image');
+    }
+
+    public function testReturnsAllFoundElements()
+    {
+        $expectedElements = ['element1', 'element2'];
+        $this->pageMock->method('findAll')->willReturn($expectedElements);
+        $elements = $this->flexible_context->assertElementsExist('image');
+        $this->assertEquals($expectedElements, $elements);
+    }
+
+    public function testReturnsTheFoundElements()
+    {
+        $expectedElements = ['element1'];
+        $this->pageMock->method('findAll')->willReturn($expectedElements);
+        $elements = $this->flexible_context->assertElementsExist('image');
+        $this->assertEquals($expectedElements, $elements);
+    }
+}

--- a/tests/Behat/FlexibleMink/Context/FlexibleContext/AssertNthElementTest.php
+++ b/tests/Behat/FlexibleMink/Context/FlexibleContext/AssertNthElementTest.php
@@ -1,0 +1,31 @@
+<?php namespace Tests\Behat\FlexibleMink\Context\FlexibleContext;
+
+use Behat\Mink\Exception\ExpectationException;
+
+/**
+ * @covers \Behat\FlexibleMink\Context\FlexibleContext::assertNthElement()
+ */
+class AssertNthElementTest extends FlexibleContextTest
+{
+    public function testThrowsExpectationExceptionWhenNoElementFound()
+    {
+        $this->pageMock->method('findAll')->willReturn([]);
+        $this->setExpectedException(ExpectationException::class, "No 'image' was not found");
+        $this->flexible_context->assertNthElement('image', 1);
+    }
+
+    public function testThrowsExpectationExceptionWhenNthElementNotFound()
+    {
+        $this->pageMock->method('findAll')->willReturn(['image1']);
+        $this->setExpectedException(ExpectationException::class, 'Element image 2 was not found');
+        $this->flexible_context->assertNthElement('image', 2);
+    }
+
+    public function testReturnsFoundNthElements()
+    {
+        $expectedElements = ['element1', 'element2'];
+        $this->pageMock->method('findAll')->willReturn($expectedElements);
+        $elements = $this->flexible_context->assertNthElement('image', 2);
+        $this->assertEquals($expectedElements[1], $elements);
+    }
+}

--- a/tests/Behat/FlexibleMink/Context/FlexibleContext/FlexibleContextTest.php
+++ b/tests/Behat/FlexibleMink/Context/FlexibleContext/FlexibleContextTest.php
@@ -1,0 +1,45 @@
+<?php namespace Tests\Behat\FlexibleMink\Context\FlexibleContext;
+
+use Behat\FlexibleMink\Context\FlexibleContext;
+use Behat\Mink\Element\DocumentElement;
+use Behat\Mink\Session;
+use PHPUnit_Framework_MockObject_MockObject;
+use PHPUnit_Framework_TestCase;
+
+/**
+ * Instantiates the FlexibleContext so it can be used in Unit Tests functions.
+ */
+abstract class FlexibleContextTest extends PHPUnit_Framework_TestCase
+{
+    /** @var Session|PHPUnit_Framework_MockObject_MockObject */
+    protected $sessionMock;
+
+    /** @var DocumentElement|PHPUnit_Framework_MockObject_MockObject */
+    protected $pageMock;
+
+    /** @var FlexibleContext|PHPUnit_Framework_MockObject_MockObject */
+    protected $flexible_context;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setUp()
+    {
+        $this->flexible_context = $this->getMock(FlexibleContext::class, ['getSession']);
+        $this->sessionMock = $this->getMock(Session::class, ['getPage'], [], '', false);
+        $this->pageMock = $this->getMock(DocumentElement::class, ['findAll'], [], '', false);
+        $this->flexible_context->method('getSession')->willReturn($this->sessionMock);
+        $this->sessionMock->method('getPage')->willReturn($this->pageMock);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function tearDown()
+    {
+        parent::tearDown();
+        $this->pageMock = null;
+        $this->sessionMock = null;
+        $this->flexible_context = null;
+    }
+}


### PR DESCRIPTION
### Issue:
We need to be able to get all elements on the page or the nth element from a page in order to confirm it exist or further steps to use them. 

### Solution:
Add functions to be able to assert elements exist on the page and to get the nth element on the page.