### PR TITLE
Add Assert Elements Exists & Nth Element Exist Step

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,6 +34,11 @@
       "Tests\\": "tests"
     }
   },
+  "autoload-dev": {
+    "psr-4": {
+      "Tests\\": "tests/"
+    }
+  },
   "repositories": [
     {
       "type": "vcs",

--- a/src/Medology/Behat/Mink/FlexibleContext.php
+++ b/src/Medology/Behat/Mink/FlexibleContext.php
@@ -358,7 +358,7 @@ class FlexibleContext extends MinkContext
         /* @noinspection PhpUnhandledExceptionInspection */
         return Spinner::waitFor(function () use ($session, $selectorType, $element) {
             if (!$allElements = $session->getPage()->findAll($selectorType, $element)) {
-                throw new ExpectationException("No '$element' was not found", $session);
+                throw new ExpectationException("No '$element' was found", $session);
             }
 
             return $allElements;

--- a/src/Medology/Behat/Mink/FlexibleContext.php
+++ b/src/Medology/Behat/Mink/FlexibleContext.php
@@ -346,7 +346,7 @@ class FlexibleContext extends MinkContext
     /**
      * Checks that elements with specified selector exist.
      *
-     * @param  string               $element      The element to search from.
+     * @param  string               $element      The element to search for.
      * @param  string|array         $selectorType selector type locator.
      * @throws ExpectationException When no element is found.
      * @return NodeElement[]        All elements found with by the given selector.
@@ -368,7 +368,7 @@ class FlexibleContext extends MinkContext
     /**
      * Checks that the nth element exists and returns it.
      *
-     * @param  string               $element      The elements to search from.
+     * @param  string               $element      The elements to search for.
      * @param  int                  $nth          This is the nth amount of the element.
      * @param  string|array         $selectorType selector type locator.
      * @throws ExpectationException When the nth element is not found.

--- a/src/Medology/Behat/Mink/FlexibleContext.php
+++ b/src/Medology/Behat/Mink/FlexibleContext.php
@@ -344,6 +344,47 @@ class FlexibleContext extends MinkContext
     }
 
     /**
+     * Checks that elements with specified selector exist.
+     *
+     * @param  string               $element      The element to search from.
+     * @param  string|array         $selectorType selector type locator.
+     * @throws ExpectationException When no element is found.
+     * @return NodeElement[]        All elements found with by the given selector.
+     */
+    public function assertElementsExist($element, $selectorType = 'css')
+    {
+        $session = $this->getSession();
+
+        /* @noinspection PhpUnhandledExceptionInspection */
+        return Spinner::waitFor(function () use ($session, $selectorType, $element) {
+            if (!$allElements = $session->getPage()->findAll($selectorType, $element)) {
+                throw new ExpectationException("No '$element' was not found", $session);
+            }
+
+            return $allElements;
+        });
+    }
+
+    /**
+     * Checks that the nth element exists and returns it.
+     *
+     * @param  string               $element      The elements to search from.
+     * @param  int                  $nth          This is the nth amount of the element.
+     * @param  string|array         $selectorType selector type locator.
+     * @throws ExpectationException When the nth element is not found.
+     * @return NodeElement          The nth element found.
+     */
+    public function assertNthElement($element, $nth, $selectorType = 'css')
+    {
+        $allElements = $this->assertElementsExist($element, $selectorType);
+        if (!isset($allElements[$nth - 1])) {
+            throw new ExpectationException("Element $element $nth was not found", $this->getSession());
+        }
+
+        return $allElements[$nth - 1];
+    }
+
+    /**
      * Clicks a visible link with specified id|title|alt|text.
      * This method overrides the MinkContext::clickLink() default behavior for clickLink to ensure that only visible
      * links are clicked.

--- a/tests/Medology/Behat/Mink/FlexibleContext/AssertElementsExistTest.php
+++ b/tests/Medology/Behat/Mink/FlexibleContext/AssertElementsExistTest.php
@@ -1,0 +1,32 @@
+<?php namespace Tests\Medology\Behat\Mink\FlexibleContext;
+
+use Behat\Mink\Exception\ExpectationException;
+
+/**
+ * @covers \Medology\Behat\Mink\FlexibleContext::assertElementsExist()
+ */
+class AssertElementsExistTest extends FlexibleContextTest
+{
+    public function testThrowsExpectationExceptionWhenElementDoesntExist()
+    {
+        $this->pageMock->method('findAll')->willReturn([]);
+        $this->expectException(ExpectationException::class);
+        $this->flexible_context->assertElementsExist('image');
+    }
+
+    public function testReturnsAllFoundElements()
+    {
+        $expectedElements = ['element1', 'element2'];
+        $this->pageMock->method('findAll')->willReturn($expectedElements);
+        $elements = $this->flexible_context->assertElementsExist('image');
+        $this->assertEquals($expectedElements, $elements);
+    }
+
+    public function testReturnsTheFoundElements()
+    {
+        $expectedElements = ['element1'];
+        $this->pageMock->method('findAll')->willReturn($expectedElements);
+        $elements = $this->flexible_context->assertElementsExist('image');
+        $this->assertEquals($expectedElements, $elements);
+    }
+}

--- a/tests/Medology/Behat/Mink/FlexibleContext/AssertElementsExistTest.php
+++ b/tests/Medology/Behat/Mink/FlexibleContext/AssertElementsExistTest.php
@@ -11,6 +11,7 @@ class AssertElementsExistTest extends FlexibleContextTest
     {
         $this->pageMock->method('findAll')->willReturn([]);
         $this->expectException(ExpectationException::class);
+        $this->expectExceptionMessage('No \'image\' was found');
         $this->flexible_context->assertElementsExist('image');
     }
 

--- a/tests/Medology/Behat/Mink/FlexibleContext/AssertNthElementTest.php
+++ b/tests/Medology/Behat/Mink/FlexibleContext/AssertNthElementTest.php
@@ -11,6 +11,7 @@ class AssertNthElementTest extends FlexibleContextTest
     {
         $this->pageMock->method('findAll')->willReturn([]);
         $this->expectException(ExpectationException::class);
+        $this->expectExceptionMessage('No \'image\' was found');
         $this->flexible_context->assertNthElement('image', 1);
     }
 
@@ -18,6 +19,7 @@ class AssertNthElementTest extends FlexibleContextTest
     {
         $this->pageMock->method('findAll')->willReturn(['image1']);
         $this->expectException(ExpectationException::class);
+        $this->expectExceptionMessage('Element image 2 was not found');
         $this->flexible_context->assertNthElement('image', 2);
     }
 

--- a/tests/Medology/Behat/Mink/FlexibleContext/AssertNthElementTest.php
+++ b/tests/Medology/Behat/Mink/FlexibleContext/AssertNthElementTest.php
@@ -1,0 +1,31 @@
+<?php namespace Tests\Medology\Behat\Mink\FlexibleContext;
+
+use Behat\Mink\Exception\ExpectationException;
+
+/**
+ * @covers \Medology\Behat\Mink\FlexibleContext::assertNthElement()
+ */
+class AssertNthElementTest extends FlexibleContextTest
+{
+    public function testThrowsExpectationExceptionWhenNoElementFound()
+    {
+        $this->pageMock->method('findAll')->willReturn([]);
+        $this->expectException(ExpectationException::class);
+        $this->flexible_context->assertNthElement('image', 1);
+    }
+
+    public function testThrowsExpectationExceptionWhenNthElementNotFound()
+    {
+        $this->pageMock->method('findAll')->willReturn(['image1']);
+        $this->expectException(ExpectationException::class);
+        $this->flexible_context->assertNthElement('image', 2);
+    }
+
+    public function testReturnsFoundNthElements()
+    {
+        $expectedElements = ['element1', 'element2'];
+        $this->pageMock->method('findAll')->willReturn($expectedElements);
+        $elements = $this->flexible_context->assertNthElement('image', 2);
+        $this->assertEquals($expectedElements[1], $elements);
+    }
+}

--- a/tests/Medology/Behat/Mink/FlexibleContext/FlexibleContextTest.php
+++ b/tests/Medology/Behat/Mink/FlexibleContext/FlexibleContextTest.php
@@ -1,0 +1,45 @@
+<?php namespace Tests\Medology\Behat\Mink\FlexibleContext;
+
+use Behat\Mink\Element\DocumentElement;
+use Behat\Mink\Session;
+use Medology\Behat\Mink\FlexibleContext;
+use PHPUnit_Framework_MockObject_MockObject;
+use PHPUnit_Framework_TestCase;
+
+/**
+ * Instantiates the FlexibleContext so it can be used in Unit Tests functions.
+ */
+abstract class FlexibleContextTest extends PHPUnit_Framework_TestCase
+{
+    /** @var Session|PHPUnit_Framework_MockObject_MockObject */
+    protected $sessionMock;
+
+    /** @var DocumentElement|PHPUnit_Framework_MockObject_MockObject */
+    protected $pageMock;
+
+    /** @var FlexibleContext|PHPUnit_Framework_MockObject_MockObject */
+    protected $flexible_context;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setUp()
+    {
+        $this->flexible_context = $this->createPartialMock(FlexibleContext::class, ['getSession']);
+        $this->sessionMock = $this->createMock(Session::class);
+        $this->pageMock = $this->createMock(DocumentElement::class);
+        $this->flexible_context->method('getSession')->willReturn($this->sessionMock);
+        $this->sessionMock->method('getPage')->willReturn($this->pageMock);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function tearDown()
+    {
+        parent::tearDown();
+        $this->pageMock = null;
+        $this->sessionMock = null;
+        $this->flexible_context = null;
+    }
+}


### PR DESCRIPTION
### Issue:
We need to be able to get all elements on the page or the nth element from a page in order to confirm it exist or further steps to use them.

### Solution:
Add functions to be able to assert elements exist on the page and to get the nth element on the page.