### PR TITLE
Moving NodeElement::press into waitFor.

### DIFF
--- a/src/Medology/Behat/Mink/FlexibleContext.php
+++ b/src/Medology/Behat/Mink/FlexibleContext.php
@@ -13,6 +13,7 @@ use Behat\Mink\Exception\ExpectationException;
 use Behat\Mink\Exception\ResponseTextException;
 use Behat\Mink\Exception\UnsupportedDriverActionException;
 use Behat\MinkExtension\Context\MinkContext;
+use Exception as GenericException;
 use InvalidArgumentException;
 use Medology\Behat\Mink\Models\Geometry\Rectangle;
 use Medology\Behat\StoreContext;
@@ -1607,6 +1608,7 @@ class FlexibleContext extends MinkContext
      *
      * @param  NodeElement          $element Element expected to be visble in the viewport.
      * @throws ExpectationException If the element was not found visible in the viewport.
+     * @throws GenericException     If the assertion did not pass before the timeout was exceeded.
      */
     public function assertNodeElementVisibleInViewport(NodeElement $element)
     {

--- a/src/Medology/Behat/Mink/FlexibleContext.php
+++ b/src/Medology/Behat/Mink/FlexibleContext.php
@@ -1203,6 +1203,7 @@ class FlexibleContext extends MinkContext
      * @throws DriverException                  When the operation cannot be performed.
      * @throws ExpectationException             If a visible button field is not found.
      * @throws UnsupportedDriverActionException When operation not supported by the driver.
+     * @throws ExpectationException             If Button is found but not visible in the viewport.
      */
     public function pressButton($locator)
     {
@@ -1213,9 +1214,10 @@ class FlexibleContext extends MinkContext
             if ($button->getAttribute('disabled') === 'disabled') {
                 throw new ExpectationException("Unable to press disabled button '$locator'.", $this->getSession());
             }
-
-            $button->press();
         });
+
+        $this->assertNodeElementVisibleInViewport($button);
+        $button->press();
     }
 
     /**
@@ -1598,6 +1600,25 @@ class FlexibleContext extends MinkContext
         }
 
         return true;
+    }
+
+    /**
+     * Asserts that the node element is visible in the viewport.
+     *
+     * @param  NodeElement          $element Element expected to be visble in the viewport.
+     * @throws ExpectationException If the element was not found visible in the viewport.
+     */
+    public function assertNodeElementVisibleInViewport(NodeElement $element)
+    {
+        Spinner::waitFor(function () use ($element) {
+            if (!$this->nodeIsVisibleInViewport($element)) {
+                throw new ExpectationException(
+                    'The following element was expected to be visible in viewport, but was not: ' .
+                    $element->getHtml(),
+                    $this->getSession()
+                );
+            }
+        });
     }
 
     /**

--- a/src/Medology/Behat/Mink/FlexibleContext.php
+++ b/src/Medology/Behat/Mink/FlexibleContext.php
@@ -1213,9 +1213,9 @@ class FlexibleContext extends MinkContext
             if ($button->getAttribute('disabled') === 'disabled') {
                 throw new ExpectationException("Unable to press disabled button '$locator'.", $this->getSession());
             }
-        });
 
-        $button->press();
+            $button->press();
+        });
     }
 
     /**

--- a/src/Medology/Behat/Mink/FlexibleContext.php
+++ b/src/Medology/Behat/Mink/FlexibleContext.php
@@ -1633,7 +1633,7 @@ class FlexibleContext extends MinkContext
     {
         $driver = $this->assertSelenium2Driver('Checks if a node Element is visible in the viewport.');
 
-        $parents = $this->getListOfAllNodeElementParents($element, 'html');
+        $parents = $this->getListOfAllNodeElementParents($element, 'body');
 
         if (!$driver->isDisplayed($element->getXpath()) || count($parents) < 1) {
             return false;

--- a/tests/Medology/Behat/Mink/FlexibleContext/PressButtonTest.php
+++ b/tests/Medology/Behat/Mink/FlexibleContext/PressButtonTest.php
@@ -7,12 +7,19 @@ use Behat\Mink\Exception\UnsupportedDriverActionException;
 use Behat\Mink\Session;
 use Exception;
 use Medology\Behat\Mink\FlexibleContext;
+use PHPUnit_Framework_MockObject_MockObject as MockObject;
 
 /**
  * @covers \Medology\Behat\Mink\FlexibleContext::pressButton()
  */
 class PressButtonTest extends FlexibleContextTest
 {
+    /**
+     * Create a flexible context with some methods declared for mocking that are used in pressButton.
+     *
+     * @param  array                      $additional_methods Additional methods not specified that may be needed.
+     * @return MockObject|FlexibleContext
+     */
     protected function getFlexibleMock(array $additional_methods = [])
     {
         $sessionMock = $this->createMock(Session::class);
@@ -72,77 +79,70 @@ class PressButtonTest extends FlexibleContextTest
     public function dataFlexibleContextExceptions()
     {
         return [
-            [
-                'flexible_context',
-                'scrollToButton',
-                $this->createMock(ExpectationException::class),
-            ],
-            [
-                'flexible_context',
-                'scrollToButton',
-                $this->createMock(UnsupportedDriverActionException::class),
-            ],
-            [
-                'flexible_context',
-                'assertNodeElementVisibleInViewport',
-                $this->createMock(ExpectationException::class),
-            ],
-            [
-                'flexible_context',
-                'assertNodeElementVisibleInViewport',
-                $this->createMock(UnsupportedDriverActionException::class),
-            ],
-            [
-                'flexible_context',
-                'assertNodeElementVisibleInViewport',
-                $this->createMock(Exception::class),
-            ],
-            [
-                'button',
-                'getAttribute',
-                $this->createMock(DriverException::class),
-            ],
-            [
-                'button',
-                'getAttribute',
-                $this->createMock(UnsupportedDriverActionException::class),
-            ],
-            [
-                'button',
-                'press',
-                $this->createMock(UnsupportedDriverActionException::class),
-            ],
-            [
-                'button',
-                'press',
-                $this->createMock(DriverException::class),
-            ],
+            ['scrollToButton',                     $this->createMock(ExpectationException::class)],
+            ['scrollToButton',                     $this->createMock(UnsupportedDriverActionException::class)],
+            ['assertNodeElementVisibleInViewport', $this->createMock(ExpectationException::class)],
+            ['assertNodeElementVisibleInViewport', $this->createMock(UnsupportedDriverActionException::class)],
+            ['assertNodeElementVisibleInViewport', $this->createMock(Exception::class)],
         ];
     }
 
     /**
-     * Asserts that an exception called from used methods bubbles up.
-     *
-     * @param string    $mock      Name of the mock being tested.
-     * @param string    $method    Name of method called on mock being tested.
-     * @param Exception $exception Exception that should be have bubbled up.
+     * Asserts that an exception called from FlexibleContext methods bubble up.
      *
      * @dataProvider dataFlexibleContextExceptions
+     * @param string    $method    Name of method called on mock being tested.
+     * @param Exception $exception Exception that should be have bubbled up.
      */
-    public function testExceptionsThrownFromFlexibleContextMethodShouldBubbleOut($mock, $method, Exception $exception)
+    public function testExceptionsThrownFromFlexibleContextMethodsShouldBubbleOut($method, Exception $exception)
     {
         $flexible_context = $this->getFlexibleMock();
         $button = $this->createPartialMock(NodeElement::class, ['getAttribute', 'press']);
+        $button->method('getAttribute')->willReturn('enabled');
 
-        if ($mock != 'button' || $method != 'getAttribute') {
-            $button->method('getAttribute')->willReturn('enabled');
-        }
-
-        if ($mock != 'flexible_context' || $method != 'scrollToButton') {
+        if ($method != 'scrollToButton') {
             $flexible_context->method('scrollToButton')->willReturn($button);
         }
 
-        ${$mock}->method($method)->willThrowException($exception);
+        $flexible_context->method($method)->willThrowException($exception);
+        $this->expectException(get_class($exception));
+
+        $flexible_context->pressButton('dsfaljklkj');
+    }
+
+    /**
+     * Exceptions thrown when calling specified mock, method combination.
+     *
+     * @return array
+     */
+    public function dataButtonExceptions()
+    {
+        return [
+            ['getAttribute', $this->createMock(DriverException::class)],
+            ['getAttribute', $this->createMock(UnsupportedDriverActionException::class)],
+            ['press',        $this->createMock(DriverException::class)],
+            ['press',        $this->createMock(UnsupportedDriverActionException::class)],
+        ];
+    }
+
+    /**
+     * Asserts that an exception called from Button methods bubble up.
+     *
+     * @dataProvider dataButtonExceptions
+     * @param string    $method    Name of method called on mock being tested.
+     * @param Exception $exception Exception that should be have bubbled up.
+     */
+    public function testExceptionsThrownFromButtonMethodsShouldBubbleOut($method, Exception $exception)
+    {
+        $flexible_context = $this->getFlexibleMock();
+        $button = $this->createPartialMock(NodeElement::class, ['getAttribute', 'press']);
+        $flexible_context->method('scrollToButton')->willReturn($button);
+
+        if ($method != 'getAttribute') {
+            $button->method('getAttribute')->willReturn('enabled');
+        }
+
+        $button->method($method)->willThrowException($exception);
         $this->expectException(get_class($exception));
 
         $flexible_context->pressButton('dsfaljklkj');

--- a/tests/Medology/Behat/Mink/FlexibleContext/PressButtonTest.php
+++ b/tests/Medology/Behat/Mink/FlexibleContext/PressButtonTest.php
@@ -1,0 +1,31 @@
+<?php namespace Tests\Medology\Behat\Mink\FlexibleContext;
+
+use Behat\Mink\Element\NodeElement;
+use Behat\Mink\Exception\ExpectationException;
+use Medology\Behat\Mink\FlexibleContext;
+
+/**
+ * @covers \Medology\Behat\Mink\FlexibleContext::pressButton()
+ */
+class PressButtonTest extends FlexibleContextTest
+{
+    public function testFailingToSeeNodeElementIsVissibleInViewportPreventsButtonFromBeingPressed()
+    {
+        // Need mock with original constructor.
+        $flexible_context = $this->getMockBuilder(FlexibleContext::class)
+            ->enableOriginalConstructor()
+            ->setMethods(['scrollToButton', 'assertNodeElementVisibleInViewport'])
+            ->getMock();
+
+        $button = $this->createPartialMock(NodeElement::class, ['getAttribute', 'press']);
+        $button->method('getAttribute')->willReturn('enabled');
+        $flexible_context->method('scrollToButton')->willReturn($button);
+
+        self::expectExceptionMessage('test');
+        $flexible_context->method('assertNodeElementVisibleInViewport')
+            ->willThrowException(new ExpectationException('test', $this->sessionMock));
+        $button->expects($this->never())->method('press');
+
+        $flexible_context->pressButton('this is a test');
+    }
+}

--- a/tests/Medology/Behat/Mink/FlexibleContext/PressButtonTest.php
+++ b/tests/Medology/Behat/Mink/FlexibleContext/PressButtonTest.php
@@ -1,7 +1,11 @@
 <?php namespace Tests\Medology\Behat\Mink\FlexibleContext;
 
 use Behat\Mink\Element\NodeElement;
+use Behat\Mink\Exception\DriverException;
 use Behat\Mink\Exception\ExpectationException;
+use Behat\Mink\Exception\UnsupportedDriverActionException;
+use Behat\Mink\Session;
+use Exception;
 use Medology\Behat\Mink\FlexibleContext;
 
 /**
@@ -9,23 +13,138 @@ use Medology\Behat\Mink\FlexibleContext;
  */
 class PressButtonTest extends FlexibleContextTest
 {
-    public function testFailingToSeeNodeElementIsVissibleInViewportPreventsButtonFromBeingPressed()
+    protected function getFlexibleMock(array $additional_methods = [])
     {
-        // Need mock with original constructor.
+        $sessionMock = $this->createMock(Session::class);
         $flexible_context = $this->getMockBuilder(FlexibleContext::class)
             ->enableOriginalConstructor()
-            ->setMethods(['scrollToButton', 'assertNodeElementVisibleInViewport'])
+            ->setMethods(
+                array_merge(['scrollToButton', 'assertNodeElementVisibleInViewport', 'getSession'], $additional_methods)
+            )
             ->getMock();
+
+        $flexible_context->method('getSession')->willReturn($sessionMock);
+
+        return $flexible_context;
+    }
+
+    public function testFailingToSeeNodeElementIsVisibleInViewportPreventsButtonFromBeingPressed()
+    {
+        // Need mock with original constructor.
+        $flexible_context = $this->getFlexibleMock();
 
         $button = $this->createPartialMock(NodeElement::class, ['getAttribute', 'press']);
         $button->method('getAttribute')->willReturn('enabled');
         $flexible_context->method('scrollToButton')->willReturn($button);
 
-        self::expectExceptionMessage('test');
+        $exception = new ExpectationException('test', $this->sessionMock);
+        $this->expectException(get_class($exception));
+        $this->expectExceptionMessage($exception->getMessage());
+
         $flexible_context->method('assertNodeElementVisibleInViewport')
-            ->willThrowException(new ExpectationException('test', $this->sessionMock));
+            ->willThrowException($exception);
         $button->expects($this->never())->method('press');
 
         $flexible_context->pressButton('this is a test');
+    }
+
+    public function testAttemptingToPressDisabledButtonThrowsException()
+    {
+        $flexible_context = $this->getFlexibleMock();
+        $button_locator = 'test';
+        $button = $this->createPartialMock(NodeElement::class, ['getAttribute', 'press']);
+
+        $button->method('getAttribute')->willReturn('disabled');
+        $flexible_context->method('scrollToButton')->willReturn($button);
+
+        $this->expectExceptionMessage(ExpectationException::class);
+        $this->expectExceptionMessage("Unable to press disabled button '$button_locator'.");
+
+        $button->expects($this->never())->method('press');
+        $flexible_context->pressButton($button_locator);
+    }
+
+    /**
+     * Exceptions thrown when calling specified mock, method combination.
+     *
+     * @return array
+     */
+    public function dataFlexibleContextExceptions()
+    {
+        return [
+            [
+                'flexible_context',
+                'scrollToButton',
+                $this->createMock(ExpectationException::class),
+            ],
+            [
+                'flexible_context',
+                'scrollToButton',
+                $this->createMock(UnsupportedDriverActionException::class),
+            ],
+            [
+                'flexible_context',
+                'assertNodeElementVisibleInViewport',
+                $this->createMock(ExpectationException::class),
+            ],
+            [
+                'flexible_context',
+                'assertNodeElementVisibleInViewport',
+                $this->createMock(UnsupportedDriverActionException::class),
+            ],
+            [
+                'flexible_context',
+                'assertNodeElementVisibleInViewport',
+                $this->createMock(Exception::class),
+            ],
+            [
+                'button',
+                'getAttribute',
+                $this->createMock(DriverException::class),
+            ],
+            [
+                'button',
+                'getAttribute',
+                $this->createMock(UnsupportedDriverActionException::class),
+            ],
+            [
+                'button',
+                'press',
+                $this->createMock(UnsupportedDriverActionException::class),
+            ],
+            [
+                'button',
+                'press',
+                $this->createMock(DriverException::class),
+            ],
+        ];
+    }
+
+    /**
+     * Asserts that an exception called from used methods bubbles up.
+     *
+     * @param string    $mock      Name of the mock being tested.
+     * @param string    $method    Name of method called on mock being tested.
+     * @param Exception $exception Exception that should be have bubbled up.
+     *
+     * @dataProvider dataFlexibleContextExceptions
+     */
+    public function testExceptionsThrownFromFlexibleContextMethodShouldBubbleOut($mock, $method, Exception $exception)
+    {
+        $flexible_context = $this->getFlexibleMock();
+        $button = $this->createPartialMock(NodeElement::class, ['getAttribute', 'press']);
+
+        if ($mock != 'button' || $method != 'getAttribute') {
+            $button->method('getAttribute')->willReturn('enabled');
+        }
+
+        if ($mock != 'flexible_context' || $method != 'scrollToButton') {
+            $flexible_context->method('scrollToButton')->willReturn($button);
+        }
+
+        ${$mock}->method($method)->willThrowException($exception);
+        $this->expectException(get_class($exception));
+
+        $flexible_context->pressButton('dsfaljklkj');
     }
 }


### PR DESCRIPTION
The pressing of the node element when pressing a button should also be
surrounded by the waitFor method.

There is a scenario that is attempting to scroll to the bottom where a button is and then press it. What's happening is that at times the scroll is triggered, and the button is attempted to be pressed before the browser has gotten to the desired scroll area. This causes an exception to be thrown but since the $button->press() is outside the waitFor lambda, the button pressing is not re-tried.

The pressing of the button should also be included in a waitFor to try and recover from an error when this happens.

Issue: Medology/stdcheck.com#7989