### PR TITLE
Implemention of nested object references with single get() method

### DIFF
--- a/features/StoreContext.feature
+++ b/features/StoreContext.feature
@@ -57,3 +57,13 @@ Feature: Store Context
      When I assert that the "body" of the "Slogan" should contain "candy"
      Then the assertion should throw an Exception
       And the assertion should fail with the message "Expected the 'body' of the 'Slogan' to contain 'candy', but found 'Eat more cake' instead"
+
+  Scenario: Chained objects/arrays retrieved successful
+    Given the following is stored as "DataObject":
+      | childData  | bar |
+    And the following is stored as "ChildDataObject":
+      | attribute  | foo |
+    And "ChildDataObject" is attached to "DataObject" with "childData" attribute
+    Then the "DataObject's childData's attribute" should be "foo"
+
+

--- a/src/Behat/FlexibleMink/Context/StoreContext.php
+++ b/src/Behat/FlexibleMink/Context/StoreContext.php
@@ -67,17 +67,16 @@ trait StoreContext
         return $this->get($key, $nth);
     }
 
-
     /**
      * Retrieves a value from a nested array or object using array list.
-     * (Modified version of data_get() laravel > 5.6)
+     * (Modified version of data_get() laravel > 5.6).
      *
      * @param  mixed    $target    The target element
      * @param  string[] $key_parts Key string dot notation
      * @param  mixed    $default   If value doesn't exists
      * @return mixed
      */
-    function data_get($target, array $key_parts, $default = null)
+    public function data_get($target, array $key_parts, $default = null)
     {
         if (!count($key_parts)) {
             return $target;
@@ -102,6 +101,7 @@ trait StoreContext
                 return $this->value($default);
             }
         }
+
         return $target;
     }
 
@@ -111,7 +111,7 @@ trait StoreContext
      * @param  string $value Closure
      * @return mixed  Result of the Closure function or $value itself
      */
-    function value($value)
+    public function value($value)
     {
         return $value instanceof Closure ? $value() : $value;
     }
@@ -124,7 +124,8 @@ trait StoreContext
      */
     private function parseKeyNested($key)
     {
-        $key_parts = explode('.', str_replace("'s ", ".", $key));
+        $key_parts = explode('.', str_replace("'s ", '.', $key));
+
         return [array_shift($key_parts), $key_parts];
     }
 
@@ -164,7 +165,6 @@ trait StoreContext
         return $nth ? $this->data_get($this->registry[$target_key][$nth - 1], $key_parts) :
             $this->data_get(end($this->registry[$target_key]), $key_parts);
     }
-
 
     /**
      * {@inheritdoc}
@@ -283,18 +283,18 @@ trait StoreContext
         $targetObj = $this->get($target_key);
         $relatedObj = $this->get($relatedModel_key);
 
-        if($targetObj && $relatedObj){
-            if(is_object($targetObj)){
-                /** Any Object models */
+        if ($targetObj && $relatedObj) {
+            if (is_object($targetObj)) {
+                /* Any Object models */
                 $targetObj->$attribute = $relatedObj;
-                /** Eloquent models */
+                /* Eloquent models */
                 is_callable([$targetObj, 'save']);
-            } elseif(is_array($targetObj)) {
-                /** Associative array */
+            } elseif (is_array($targetObj)) {
+                /* Associative array */
                 $targetObj[$attribute] = $relatedObj;
             } else {
-                throw new Exception("The type of '$target_key' is ".gettype($targetObj).". 
-                But expected Array or Object");
+                throw new Exception("The type of '$target_key' is ".gettype($targetObj).'. 
+                But expected Array or Object');
             }
 
             $this->put($targetObj, $target_key);


### PR DESCRIPTION
**Cause:** There were not easy way to access stored nested Object or Arrays , usually Eloquent model relations in the test steps.

**Solution:** Modified `StoreContext::get()` method in order to archive this. 
**Syntax:** In testing steps `"Foo's Bar's attr"` or `"Foo.Bar.attr"`  with give you access to either `Foo()-Bar()->attr` or `Foo[Bar]->attr` or `Foo[Bar][attr]`. 
There is no limit for the chain. You can nest as many times as you like and the is globally accessible