### PR TITLE
Fix the parallelization for PHP 7.1

### DIFF
--- a/src/Behat/ParallelWorker/ServiceContainer/ParallelWorkerExtension.php
+++ b/src/Behat/ParallelWorker/ServiceContainer/ParallelWorkerExtension.php
@@ -26,7 +26,7 @@ class ParallelWorkerExtension implements ExtensionInterface
         $definition = new Definition('Behat\ParallelWorker\Controller\ParallelWorkerController', [
             new Reference(GherkinExtension::MANAGER_ID),
         ]);
-        $definition->addTag(CliExtension::CONTROLLER_TAG);
+        $definition->addTag(CliExtension::CONTROLLER_TAG, ['priority' => 100]);
         $container->setDefinition(CliExtension::CONTROLLER_TAG . '.parallel_worker', $definition);
     }
 


### PR DESCRIPTION
### Context
Behat uses the Symfony dependency injection component. So, every single decorator has a priority.

In the case of PHP 7. Behat, fails to load the class on time and is not executed the expected method. 

### Fix
By providing a value for the priority tag attribute you can influence the order in which middlewares/commands are added and loaded.

#### Thanks
@johnnie502 