### PR TITLE
Press button update1.0

### DIFF
--- a/src/Behat/FlexibleMink/Context/FlexibleContext.php
+++ b/src/Behat/FlexibleMink/Context/FlexibleContext.php
@@ -942,7 +942,24 @@ class FlexibleContext extends MinkContext
             }
         });
 
+        $this->assertNodeElementVisibleInViewport($button);
         $button->press();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function assertNodeElementVisibleInViewport(NodeElement $element)
+    {
+        $this->waitFor(function () use ($element) {
+            if (!$this->nodeIsVisibleInViewport($element)) {
+                throw new ExpectationException(
+                    'The following element was expected to be visible in viewport, but was not: ' .
+                        $element->getHtml(),
+                    $this->getSession()
+                );
+            }
+        });
     }
 
     /**
@@ -1343,11 +1360,12 @@ JS
     private function getListOfAllNodeElementParents(NodeElement $nodeElement, $stopAt)
     {
         $nodeElements = [];
-        while ($nodeElement->getParent() instanceof NodeElement) {
-            $nodeElements[] = ($nodeElement = $nodeElement->getParent());
+        while (($nodeElement = $nodeElement->getParent()) instanceof NodeElement) {
             if (strtolower($nodeElement->getTagName()) === strtolower($stopAt)) {
                 break;
             }
+
+            $nodeElements[] = $nodeElement;
         }
 
         return $nodeElements;

--- a/src/Behat/FlexibleMink/PseudoInterface/FlexibleContextInterface.php
+++ b/src/Behat/FlexibleMink/PseudoInterface/FlexibleContextInterface.php
@@ -11,6 +11,7 @@ use Behat\Mink\Exception\ExpectationException;
 use Behat\Mink\Exception\ResponseTextException;
 use Behat\Mink\Exception\UnsupportedDriverActionException;
 use Behat\Mink\Session;
+use Exception;
 use InvalidArgumentException;
 
 /**
@@ -380,6 +381,7 @@ trait FlexibleContextInterface
      * @see MinkContext::pressButton
      * @param  string               $button button id, inner text, value or alt
      * @throws ExpectationException If a visible button field is not found.
+     * @throws ExpectationException If Button is found but not visible in the viewport.
      */
     abstract public function pressButton($button);
 
@@ -452,4 +454,13 @@ trait FlexibleContextInterface
      * @throws ExpectationException When the radio button is checked.
      */
     abstract public function assertRadioButtonNotChecked($label);
+
+    /**
+     * Asserts that the node element is visible in the viewport.
+     *
+     * @param  NodeElement          $element Element expected to be visble in the viewport.
+     * @throws ExpectationException If the element was not found visible in the viewport.
+     * @throws Exception            If the assertion did not pass before the timeout was exceeded.
+     */
+    abstract public function assertNodeElementVisibleInViewport(NodeElement $element);
 }

--- a/tests/Behat/FlexibleMink/Context/FlexibleContext/PressButtonTest.php
+++ b/tests/Behat/FlexibleMink/Context/FlexibleContext/PressButtonTest.php
@@ -35,6 +35,9 @@ class PressButtonTest extends FlexibleContextTest
         return $flexible_context;
     }
 
+    /**
+     * Asserts an exception is thrown and the press method is not triggered if the node is not visible in the viewport.
+     */
     public function testFailingToSeeNodeElementIsVisibleInViewportPreventsButtonFromBeingPressed()
     {
         // Need mock with original constructor.
@@ -54,6 +57,9 @@ class PressButtonTest extends FlexibleContextTest
         $flexible_context->pressButton('this is a test');
     }
 
+    /**
+     * Asserts an exception is thrown and the press method is not triggered if the button is disabled.
+     */
     public function testAttemptingToPressDisabledButtonThrowsException()
     {
         $flexible_context = $this->getFlexibleMock();

--- a/tests/Behat/FlexibleMink/Context/FlexibleContext/PressButtonTest.php
+++ b/tests/Behat/FlexibleMink/Context/FlexibleContext/PressButtonTest.php
@@ -1,0 +1,163 @@
+<?php namespace Tests\Behat\FlexibleMink\Context\FlexibleContext;
+
+use Behat\FlexibleMink\Context\FlexibleContext;
+use Behat\Mink\Element\NodeElement;
+use Behat\Mink\Exception\DriverException;
+use Behat\Mink\Exception\ExpectationException;
+use Behat\Mink\Exception\UnsupportedDriverActionException;
+use Behat\Mink\Session;
+use Exception;
+use PHPUnit_Framework_MockObject_MockObject as MockObject;
+
+/**
+ * @covers \Behat\FlexibleMink\Context\FlexibleContext::pressButton()
+ */
+class PressButtonTest extends FlexibleContextTest
+{
+    /**
+     * Create a flexible context with some methods declared for mocking that are used in pressButton.
+     *
+     * @param  array                      $additional_methods Additional methods not specified that may be needed.
+     * @return MockObject|FlexibleContext
+     */
+    protected function getFlexibleMock(array $additional_methods = [])
+    {
+        $sessionMock = $this->getMock(Session::class, [], [], '', false);
+        $flexible_context = $this->getMockBuilder(FlexibleContext::class)
+            ->enableOriginalConstructor()
+            ->setMethods(
+                array_merge(['scrollToButton', 'assertNodeElementVisibleInViewport', 'getSession'], $additional_methods)
+            )
+            ->getMock();
+
+        $flexible_context->method('getSession')->willReturn($sessionMock);
+
+        return $flexible_context;
+    }
+
+    public function testFailingToSeeNodeElementIsVisibleInViewportPreventsButtonFromBeingPressed()
+    {
+        // Need mock with original constructor.
+        $flexible_context = $this->getFlexibleMock();
+
+        $button = $this->getMock(NodeElement::class, ['getAttribute', 'press'], [], '', false);
+        $button->method('getAttribute')->willReturn('enabled');
+        $flexible_context->method('scrollToButton')->willReturn($button);
+
+        $exception = new ExpectationException('test', $this->sessionMock);
+        $this->setExpectedException(get_class($exception), $exception->getMessage());
+
+        $flexible_context->method('assertNodeElementVisibleInViewport')
+            ->willThrowException($exception);
+        $button->expects($this->never())->method('press');
+
+        $flexible_context->pressButton('this is a test');
+    }
+
+    public function testAttemptingToPressDisabledButtonThrowsException()
+    {
+        $flexible_context = $this->getFlexibleMock();
+        $button_locator = 'test';
+        $button = $this->getMock(NodeElement::class, ['getAttribute', 'press'], [], '', false);
+
+        $button->method('getAttribute')->willReturn('disabled');
+        $flexible_context->method('scrollToButton')->willReturn($button);
+
+        $this->setExpectedException(ExpectationException::class, "Unable to press disabled button '$button_locator'.");
+
+        $button->expects($this->never())->method('press');
+        $flexible_context->pressButton($button_locator);
+    }
+
+    /**
+     * Exceptions thrown when calling specified mock, method combination.
+     *
+     * @return array
+     */
+    public function dataFlexibleContextExceptions()
+    {
+        return [
+            [
+                'scrollToButton',
+                $this->getMock(ExpectationException::class, [], [], '', false),
+            ],
+            [
+                'scrollToButton',
+                $this->getMock(UnsupportedDriverActionException::class, [], [], '', false),
+            ],
+            [
+                'assertNodeElementVisibleInViewport',
+                $this->getMock(ExpectationException::class, [], [], '', false),
+            ],
+            [
+                'assertNodeElementVisibleInViewport',
+                $this->getMock(UnsupportedDriverActionException::class, [], [], '', false),
+            ],
+            [
+                'assertNodeElementVisibleInViewport',
+                $this->getMock(Exception::class, [], [], '', false),
+            ],
+        ];
+    }
+
+    /**
+     * Asserts that an exception called from FlexibleContext methods bubble up.
+     *
+     * @dataProvider dataFlexibleContextExceptions
+     * @param string    $method    Name of method called on mock being tested.
+     * @param Exception $exception Exception that should be have bubbled up.
+     */
+    public function testExceptionsThrownFromFlexibleContextMethodsShouldBubbleOut($method, Exception $exception)
+    {
+        $flexible_context = $this->getFlexibleMock();
+        $button = $this->getMock(NodeElement::class, ['getAttribute', 'press'], [], '', false);
+        $button->method('getAttribute')->willReturn('enabled');
+
+        if ($method != 'scrollToButton') {
+            $flexible_context->method('scrollToButton')->willReturn($button);
+        }
+
+        $flexible_context->method($method)->willThrowException($exception);
+        $this->setExpectedException(get_class($exception));
+
+        $flexible_context->pressButton('dsfaljklkj');
+    }
+
+    /**
+     * Exceptions thrown when calling specified mock, method combination.
+     *
+     * @return array
+     */
+    public function dataButtonExceptions()
+    {
+        return [
+            ['getAttribute', $this->getMock(DriverException::class, [], [], '', false)],
+            ['getAttribute', $this->getMock(UnsupportedDriverActionException::class, [], [], '', false)],
+            ['press',        $this->getMock(DriverException::class, [], [], '', false)],
+            ['press',        $this->getMock(UnsupportedDriverActionException::class, [], [], '', false)],
+        ];
+    }
+
+    /**
+     * Asserts that an exception called from Button methods bubble up.
+     *
+     * @dataProvider dataButtonExceptions
+     * @param string    $method    Name of method called on mock being tested.
+     * @param Exception $exception Exception that should be have bubbled up.
+     */
+    public function testExceptionsThrownFromButtonMethodsShouldBubbleOut($method, Exception $exception)
+    {
+        $flexible_context = $this->getFlexibleMock();
+        $button = $this->getMock(NodeElement::class, ['getAttribute', 'press'], [], '', false);
+        $flexible_context->method('scrollToButton')->willReturn($button);
+
+        if ($method != 'getAttribute') {
+            $button->method('getAttribute')->willReturn('enabled');
+        }
+
+        $button->method($method)->willThrowException($exception);
+        $this->setExpectedException(get_class($exception));
+
+        $flexible_context->pressButton('dsfaljklkj');
+    }
+}

--- a/web/big-page.html
+++ b/web/big-page.html
@@ -14,8 +14,10 @@
     </style>
 </head>
 <body>
-<div class="top">Scroll down.</div>
-<div class="bottom" data-qa-id="the almost-last div">Hello!</div>
-<div class="bottom" data-qa-id="the last div">Hello!</div>
+    <div>
+        <div class="top">Scroll down.</div>
+        <div class="bottom" data-qa-id="the almost-last div">Hello!</div>
+        <div class="bottom" data-qa-id="the last div">Hello!</div>
+    </div>
 </body>
 </html>

--- a/web/button-disabled.html
+++ b/web/button-disabled.html
@@ -13,12 +13,14 @@
   </script>
 </head>
 <body>
-    <button type="button" id="disabled-button" disabled>Disabled Button</button>
-    <button type="button" id="enabled-button">Enabled Button</button>
-    <br>
-    <br>
-    <button type="button" onclick="enableDisabledButton()">Enable Disabled Button</button>
-    <button type="button" onclick="disableEnabledButton()">Disable Enabled Button</button>
+    <div>
+        <button type="button" id="disabled-button" disabled>Disabled Button</button>
+        <button type="button" id="enabled-button">Enabled Button</button>
+        <br>
+        <br>
+        <button type="button" onclick="enableDisabledButton()">Enable Disabled Button</button>
+        <button type="button" onclick="disableEnabledButton()">Disable Enabled Button</button>
+    </div>
 </body>
 </html>
 

--- a/web/select-option.html
+++ b/web/select-option.html
@@ -5,19 +5,22 @@
     <title>Assert Option in Select</title>
 </head>
 <body>
-<h1>Select</h1>
-    <form>
-        <label for="country">Country</label>
-        <select id="country">
-            <option>US</option>
-            <option>China</option>
-            <option>Canada</option>
-        </select>
-        <label for="state">State</label>
-        <select id="state">
-        </select>
-    </form>
-    <button onclick="updateSelectWithDelay()">Update select with delay</button>
+    <div>
+        <h1>Select</h1>
+        <form>
+            <label for="country">Country</label>
+            <select id="country">
+                <option>US</option>
+                <option>China</option>
+                <option>Canada</option>
+            </select>
+            <label for="state">State</label>
+            <select id="state">
+            </select>
+        </form>
+
+        <button onclick="updateSelectWithDelay()">Update select with delay</button>
+    </div>
 <script>
     function updateSelectWithDelay() {
         setTimeout(function() {


### PR DESCRIPTION
Merging again changes addressed by Joel on PR https://github.com/Medology/FlexibleMink/pull/249

The pressing of the node element when pressing a button should also be
surrounded by the waitFor method.

There is a scenario that is attempting to scroll to the bottom where a button is and then press it.  What's happening is that at times the scroll is triggered, and the button is attempted to be pressed before the browser has gotten to the desired scroll area. This causes an exception to be thrown but since the `$button->press()` is outside the waitFor lambda, the button pressing is not re-tried.

The pressing of the button should also be included in a `waitFor` to try and recover from an error when this happens.

Issue: Medology/stdcheck.com#7989