### PR TITLE
Patch for complex key

### DIFF
--- a/features/StoreContext.feature
+++ b/features/StoreContext.feature
@@ -23,7 +23,7 @@ Feature: Store Context
      Then the "Person" should be "Bob"
       And the "Thing" should be "Bob"
 
-  Scenario: Assertion fails if the stored thing is not what's expected
+  Scenario: Assertion fails if the stored thing is not what`s expected
     Given the value "me, Dio!" is stored as "this"
      When I assert that the "this" should be "a normal adventure"
      Then the assertion should throw an Exception
@@ -82,7 +82,7 @@ Feature: Store Context
      And the following is stored as "ChildDataObject":
       | attribute  | foo |
      And "ChildDataObject" is attached to "DataObject" with "childData" attribute
-    Then the "DataObject's childData's attribute" should be "foo"
+    Then the "DataObject`s childData`s attribute" should be "foo"
 
   Scenario: Chained objects/arrays 3rd level retrieves successful
     Given the following is stored as "DataObject":
@@ -93,14 +93,14 @@ Feature: Store Context
       | attribute       | foo |
       And "GrandChildDataObject" is attached to "ChildDataObject" with "grandchildData" attribute
       And "ChildDataObject" is attached to "DataObject" with "childData" attribute
-     Then the "DataObject's childData's grandchildData's attribute" should be "foo"
+     Then the "DataObject`s childData`s grandchildData`s attribute" should be "foo"
 
   Scenario: Chained objects/arrays non-object retrieval should throw an Exception
     Given the following is stored as "DataObject":
       | childData  | bar |
-     When I assert that the "DataObject's childData's grandchildData's attribute" should be "foo"
+     When I assert that the "DataObject`s childData`s grandchildData`s attribute" should be "foo"
      Then the assertion should throw an Exception
-      And the assertion should fail with the message "Expected DataObject's childData's grandchildData's attribute to be 'foo', but it was NULL"
+      And the assertion should fail with the message "Expected DataObject`s childData`s grandchildData`s attribute to be 'foo', but it was NULL"
 
    Scenario: Data assigned to non-object/non-array property/key throw an Exception
      Given the value "dataValue" is stored as "data"

--- a/features/StoreContext.feature
+++ b/features/StoreContext.feature
@@ -76,10 +76,35 @@ Feature: Store Context
      Then the assertion should throw an Exception
       And the assertion should fail with the message "Expected the 'orderId' of the 'Commission' to contain 'order-1234', but found 'order-4321' instead"
 
-  Scenario: Chained objects/arrays retrieved successful
+  Scenario: Chained objects/arrays 2nd level retrieves successful
     Given the following is stored as "DataObject":
       | childData  | bar |
-    And the following is stored as "ChildDataObject":
+     And the following is stored as "ChildDataObject":
       | attribute  | foo |
-    And "ChildDataObject" is attached to "DataObject" with "childData" attribute
+     And "ChildDataObject" is attached to "DataObject" with "childData" attribute
     Then the "DataObject's childData's attribute" should be "foo"
+
+  Scenario: Chained objects/arrays 3rd level retrieves successful
+    Given the following is stored as "DataObject":
+      | childData       | bar |
+      And the following is stored as "ChildDataObject":
+      | grandchildData  | foo |
+      And the following is stored as "GrandChildDataObject":
+      | attribute       | foo |
+      And "GrandChildDataObject" is attached to "ChildDataObject" with "grandchildData" attribute
+      And "ChildDataObject" is attached to "DataObject" with "childData" attribute
+     Then the "DataObject's childData's grandchildData's attribute" should be "foo"
+
+  Scenario: Chained objects/arrays non-object retrieval should throw an Exception
+    Given the following is stored as "DataObject":
+      | childData  | bar |
+     When I assert that the "DataObject's childData's grandchildData's attribute" should be "foo"
+     Then the assertion should throw an Exception
+      And the assertion should fail with the message "Expected DataObject's childData's grandchildData's attribute to be 'foo', but it was NULL"
+
+   Scenario: Data assigned to non-object/non-array property/key throw an Exception
+     Given the value "dataValue" is stored as "data"
+       And the value "bar" is stored as "foo"
+      When I assert that "data" is attached to "foo" with "property" attribute
+      Then the assertion should throw an InvalidTypeException
+       And the assertion should fail with the message "Expected type for 'foo' is array/object but 'string' given"

--- a/features/StoreContext.feature
+++ b/features/StoreContext.feature
@@ -75,3 +75,11 @@ Feature: Store Context
      When I assert that the "'orderId'" of the "Commission" should contain "order-1234"
      Then the assertion should throw an Exception
       And the assertion should fail with the message "Expected the 'orderId' of the 'Commission' to contain 'order-1234', but found 'order-4321' instead"
+
+  Scenario: Chained objects/arrays retrieved successful
+    Given the following is stored as "DataObject":
+      | childData  | bar |
+    And the following is stored as "ChildDataObject":
+      | attribute  | foo |
+    And "ChildDataObject" is attached to "DataObject" with "childData" attribute
+    Then the "DataObject's childData's attribute" should be "foo"

--- a/src/Behat/FlexibleMink/Context/StoreContext.php
+++ b/src/Behat/FlexibleMink/Context/StoreContext.php
@@ -138,14 +138,14 @@ trait StoreContext
     }
 
     /**
-     * Converts a key part of the form "foo's bar" into "foo" and "bar".
+     * Converts a key part of the form "foo`s bar" into "foo" and "bar".
      *
      * @param  string $key The key name to parse
      * @return array  [base key, nested_keys|null]
      */
     private function parseKeyNested($key)
     {
-        $key_parts = explode('.', str_replace("'s ", '.', $key));
+        $key_parts = explode("`s ", $key);
 
         return [array_shift($key_parts), $key_parts];
     }

--- a/src/Behat/FlexibleMink/Context/StoreContext.php
+++ b/src/Behat/FlexibleMink/Context/StoreContext.php
@@ -145,7 +145,7 @@ trait StoreContext
      */
     private function parseKeyNested($key)
     {
-        $key_parts = explode("`s ", $key);
+        $key_parts = explode('`s ', $key);
 
         return [array_shift($key_parts), $key_parts];
     }

--- a/src/Behat/FlexibleMink/Context/StoreContext.php
+++ b/src/Behat/FlexibleMink/Context/StoreContext.php
@@ -469,7 +469,7 @@ trait StoreContext
                 /* Any Object models */
                 $targetObj->$attribute = $relatedObj;
                 /* Eloquent models */
-                if(is_callable([$targetObj, 'save'])){
+                if (is_callable([$targetObj, 'save'])){
                     $targetObj->save();
                 }
             } elseif (is_array($targetObj)) {

--- a/src/Behat/FlexibleMink/Context/StoreContext.php
+++ b/src/Behat/FlexibleMink/Context/StoreContext.php
@@ -2,7 +2,9 @@
 
 namespace Behat\FlexibleMink\Context;
 
+use ArrayAccess;
 use Behat\FlexibleMink\PseudoInterface\StoreContextInterface;
+use Closure;
 use DateTime;
 use Exception;
 use InvalidArgumentException;
@@ -85,6 +87,68 @@ trait StoreContext
     }
 
     /**
+     * Retrieves a value from a nested array or object using array list.
+     * (Modified version of data_get() laravel > 5.6).
+     *
+     * @param  mixed    $target    The target element
+     * @param  string[] $key_parts Key string dot notation
+     * @param  mixed    $default   If value doesn't exists
+     * @return mixed
+     */
+    public function data_get($target, array $key_parts, $default = null)
+    {
+        if (!count($key_parts)) {
+            return $target;
+        }
+        foreach ($key_parts as $segment) {
+            if (is_array($target)) {
+                if (!array_key_exists($segment, $target)) {
+                    return $this->value($default);
+                }
+                $target = $target[$segment];
+            } elseif ($target instanceof ArrayAccess) {
+                if (!isset($target[$segment])) {
+                    return $this->value($default);
+                }
+                $target = $target[$segment];
+            } elseif (is_object($target)) {
+                if (!isset($target->{$segment})) {
+                    return $this->value($default);
+                }
+                $target = $target->{$segment};
+            } else {
+                return $this->value($default);
+            }
+        }
+
+        return $target;
+    }
+
+    /**
+     * Returns value itself or Closure will be executed and return result.
+     *
+     * @param  string $value Closure
+     * @return mixed  Result of the Closure function or $value itself
+     */
+    public function value($value)
+    {
+        return $value instanceof Closure ? $value() : $value;
+    }
+
+    /**
+     * Converts a key part of the form "foo's bar" into "foo" and "bar".
+     *
+     * @param  string $key The key name to parse
+     * @return array  [base key, nested_keys|null]
+     */
+    private function parseKeyNested($key)
+    {
+        $key_parts = explode('.', str_replace("'s ", '.', $key));
+
+        return [array_shift($key_parts), $key_parts];
+    }
+
+    /**
      * Converts a key of the form "nth thing" into "n" and "thing".
      *
      * @param  string $key The key to parse
@@ -111,11 +175,14 @@ trait StoreContext
             list($key, $nth) = $this->parseKey($key);
         }
 
-        if (!$this->isStored($key, $nth)) {
+        list($target_key, $key_parts) = $this->parseKeyNested($key);
+
+        if (!$this->isStored($target_key, $nth)) {
             return;
         }
 
-        return $nth ? $this->registry[$key][$nth - 1] : end($this->registry[$key]);
+        return $nth ? $this->data_get($this->registry[$target_key][$nth - 1], $key_parts) :
+            $this->data_get(end($this->registry[$target_key]), $key_parts);
     }
 
     /**
@@ -378,6 +445,38 @@ trait StoreContext
         $actual = $this->getThingProperty($thing, $property);
         if (strpos($actual, $expected) === false) {
             throw new Exception("Expected the '$property' of the '$thing' to contain '$expected', but found '$actual' instead");
+        }
+    }
+
+    /**
+     * Assign the element of given key to the target object/array under given attribute/key.
+     *
+     * @Given /^"([^"]*)" is attached to "([^"]*)" with "([^"]*)" attribute$/
+     * @param  string    $relatedModel_key Key of the Element to be assigned
+     * @param  string    $target_key       Base array/object key
+     * @param  string    $attribute        Attribute or key of the base element
+     * @throws Exception If Target element is not object or array
+     */
+    public function assignToObjectAttribute($relatedModel_key, $target_key, $attribute)
+    {
+        $targetObj = $this->get($target_key);
+        $relatedObj = $this->get($relatedModel_key);
+
+        if ($targetObj && $relatedObj) {
+            if (is_object($targetObj)) {
+                /* Any Object models */
+                $targetObj->$attribute = $relatedObj;
+                /* Eloquent models */
+                is_callable([$targetObj, 'save']);
+            } elseif (is_array($targetObj)) {
+                /* Associative array */
+                $targetObj[$attribute] = $relatedObj;
+            } else {
+                throw new Exception("The type of '$target_key' is ".gettype($targetObj).'. 
+                But expected Array or Object');
+            }
+
+            $this->put($targetObj, $target_key);
         }
     }
 }

--- a/src/Behat/FlexibleMink/Context/StoreContext.php
+++ b/src/Behat/FlexibleMink/Context/StoreContext.php
@@ -469,7 +469,7 @@ trait StoreContext
                 /* Any Object models */
                 $targetObj->$attribute = $relatedObj;
                 /* Eloquent models */
-                if (is_callable([$targetObj, 'save'])){
+                if (is_callable([$targetObj, 'save'])) {
                     $targetObj->save();
                 }
             } elseif (is_array($targetObj)) {


### PR DESCRIPTION
**Issue:** 
Existing Behat tests conflicts with new complex_key feature. There are many key names containing `'s` (example: `Order's account`). 

**Solution:** 
Just changed the sign from **`'`** to **`** (backtick).