### PR TITLE
Complex key patch

### DIFF
--- a/features/StoreContext.feature
+++ b/features/StoreContext.feature
@@ -82,7 +82,7 @@ Feature: Store Context
      And the following is stored as "ChildDataObject":
       | attribute  | foo |
      And "ChildDataObject" is stored as property "childData" of "DataObject"
-    Then the "DataObject's childData's attribute" should be "foo"
+    Then the "DataObject`s childData`s attribute" should be "foo"
 
   Scenario: Chained objects/arrays 3rd level retrieves successful
     Given the following is stored as "DataObject":
@@ -93,14 +93,14 @@ Feature: Store Context
       | attribute       | foo |
       And "GrandChildDataObject" is stored as property "grandchildData" of "ChildDataObject"
       And "ChildDataObject" is stored as property "childData" of "DataObject"
-     Then the "DataObject's childData's grandchildData's attribute" should be "foo"
+     Then the "DataObject`s childData`s grandchildData`s attribute" should be "foo"
 
   Scenario: Chained objects/arrays non-object retrieval should throw an Exception
     Given the following is stored as "DataObject":
       | childData  | bar |
-     When I assert that the "DataObject's childData's grandchildData's attribute" should be "foo"
+     When I assert that the "DataObject`s childData`s grandchildData`s attribute" should be "foo"
      Then the assertion should throw an Exception
-      And the assertion should fail with the message "Expected DataObject's childData's grandchildData's attribute to be 'foo', but it was NULL"
+      And the assertion should fail with the message "Expected DataObject`s childData`s grandchildData`s attribute to be 'foo', but it was NULL"
 
    Scenario: Data assigned to non-object/non-array property/key throw an Exception
      Given the value "dataValue" is stored as "data"

--- a/features/StoreContext.feature
+++ b/features/StoreContext.feature
@@ -82,7 +82,7 @@ Feature: Store Context
      And the following is stored as "ChildDataObject":
       | attribute  | foo |
      And "ChildDataObject" is stored as property "childData" of "DataObject"
-    Then the "DataObject`s childData`s attribute" should be "foo"
+    Then the "DataObject's childData's attribute" should be "foo"
 
   Scenario: Chained objects/arrays 3rd level retrieves successful
     Given the following is stored as "DataObject":
@@ -93,18 +93,23 @@ Feature: Store Context
       | attribute       | foo |
       And "GrandChildDataObject" is stored as property "grandchildData" of "ChildDataObject"
       And "ChildDataObject" is stored as property "childData" of "DataObject"
-     Then the "DataObject`s childData`s grandchildData`s attribute" should be "foo"
+     Then the "DataObject's childData's grandchildData's attribute" should be "foo"
 
   Scenario: Chained objects/arrays non-object retrieval should throw an Exception
     Given the following is stored as "DataObject":
       | childData  | bar |
-     When I assert that the "DataObject`s childData`s grandchildData`s attribute" should be "foo"
+     When I assert that the "DataObject's childData's grandchildData's attribute" should be "foo"
      Then the assertion should throw an Exception
-      And the assertion should fail with the message "Expected DataObject`s childData`s grandchildData`s attribute to be 'foo', but it was NULL"
+      And the assertion should fail with the message "Expected DataObject's childData's grandchildData's attribute to be 'foo', but it was NULL"
 
-   Scenario: Data assigned to non-object/non-array property/key throw an Exception
-     Given the value "dataValue" is stored as "data"
-       And the value "bar" is stored as "foo"
-      When I assert that "data" is stored as property "someProperty" of "foo"
-      Then the assertion should throw an InvalidTypeException
-       And the assertion should fail with the message "Expected type for 'foo' is array/object but 'string' given"
+  Scenario: Data assigned to non-object/non-array property/key throw an Exception
+    Given the value "dataValue" is stored as "data"
+      And the value "bar" is stored as "foo"
+     When I assert that "data" is stored as property "someProperty" of "foo"
+     Then the assertion should throw an InvalidTypeException
+      And the assertion should fail with the message "Expected type for 'foo' is array/object but 'string' given"
+
+  Scenario: Non-complex key retrieves successful
+    Given the value "dataValue" is stored as "data's foo"
+     When I assert that the "data's foo" should be "dataValue"
+     Then the assertion should pass

--- a/src/Behat/FlexibleMink/Context/StoreContext.php
+++ b/src/Behat/FlexibleMink/Context/StoreContext.php
@@ -134,14 +134,14 @@ trait StoreContext
     }
 
     /**
-     * Converts a key part of the form "foo's bar" into "foo" and "bar".
+     * Converts a key part of the form "foo`s bar" into "foo" and "bar".
      *
      * @param  string $key The key name to parse
      * @return array  [base key, nested_keys|null]
      */
     private function parseKeyNested($key)
     {
-        $key_parts = explode('.', str_replace("'s ", '.', $key));
+        $key_parts = explode('`s ', $key);
 
         return [array_shift($key_parts), $key_parts];
     }

--- a/tests/Behat/FlexibleMink/Context/StoreContextTest.php
+++ b/tests/Behat/FlexibleMink/Context/StoreContextTest.php
@@ -501,12 +501,8 @@ class StoreContextTest extends PHPUnit_Framework_TestCase
      */
     public function testParseKeyNested()
     {
-        $this->assertEquals(['Object', ['property']], $this->parseKeyNested("Object's property"));
+        $this->assertEquals(['Object', ['property']], $this->parseKeyNested("Object`s property"));
         $this->assertEquals(['Object', ['ChildObject', 'property']],
-            $this->parseKeyNested("Object's ChildObject's property"));
-        $this->assertEquals(['Object', ['ChildObject', 'property']],
-            $this->parseKeyNested('Object.ChildObject.property'));
-        $this->assertEquals(['Object', ['ChildObject', 'property']],
-            $this->parseKeyNested('Object.ChildObject.property'));
+            $this->parseKeyNested("Object`s ChildObject`s property"));
     }
 }

--- a/tests/Behat/FlexibleMink/Context/StoreContextTest.php
+++ b/tests/Behat/FlexibleMink/Context/StoreContextTest.php
@@ -501,8 +501,8 @@ class StoreContextTest extends PHPUnit_Framework_TestCase
      */
     public function testParseKeyNested()
     {
-        $this->assertEquals(['Object', ['property']], $this->parseKeyNested('Object`s property'));
+        $this->assertEquals(['Object', ['property']], $this->parseKeyNested('Object\'s property'));
         $this->assertEquals(['Object', ['ChildObject', 'property']],
-            $this->parseKeyNested('Object`s ChildObject`s property'));
+            $this->parseKeyNested('Object\'s ChildObject\'s property'));
     }
 }

--- a/tests/Behat/FlexibleMink/Context/StoreContextTest.php
+++ b/tests/Behat/FlexibleMink/Context/StoreContextTest.php
@@ -501,8 +501,8 @@ class StoreContextTest extends PHPUnit_Framework_TestCase
      */
     public function testParseKeyNested()
     {
-        $this->assertEquals(['Object', ['property']], $this->parseKeyNested("Object`s property"));
+        $this->assertEquals(['Object', ['property']], $this->parseKeyNested('Object`s property'));
         $this->assertEquals(['Object', ['ChildObject', 'property']],
-            $this->parseKeyNested("Object`s ChildObject`s property"));
+            $this->parseKeyNested('Object`s ChildObject`s property'));
     }
 }


### PR DESCRIPTION
**Issue:** 
Existing Behat tests conflicts with new complex_key feature. There are many key names containing `'s` (example: `Order's account`). 

**Solution:** 
Made the method checking all possible syntax of key. Returning the stored value if key exists as non-parsed version, if not checking for nested key