### PR TITLE
Adding TraversableElement as parameter in pressButton and ScrollToBut…

### DIFF
--- a/src/Behat/FlexibleMink/Context/FlexibleContext.php
+++ b/src/Behat/FlexibleMink/Context/FlexibleContext.php
@@ -416,11 +416,13 @@ class FlexibleContext extends MinkContext
     /**
      * {@inheritdoc}
      */
-    public function scrollToButton($locator)
+    public function scrollToButton($locator, TraversableElement $context = null)
     {
         $locator = $this->fixStepArgument($locator);
 
-        $buttons = $this->getSession()->getPage()->findAll('named', ['button', $locator]);
+        $context = $context ? $context : $this->getSession()->getPage();
+
+        $buttons = $context->findAll('named', ['button', $locator]);
 
         if (!($element = $this->scrollWindowToFirstVisibleElement($buttons))) {
             throw new ExpectationException("No visible button found for '$locator'", $this->getSession());
@@ -929,11 +931,11 @@ class FlexibleContext extends MinkContext
     /**
      * {@inheritdoc}
      */
-    public function pressButton($locator)
+    public function pressButton($locator, TraversableElement $context = null)
     {
         /** @var NodeElement $button */
-        $button = $this->waitFor(function () use ($locator) {
-            return $this->scrollToButton($locator);
+        $button = $this->waitFor(function () use ($locator, $context) {
+            return $this->scrollToButton($locator, $context);
         });
 
         $this->waitFor(function () use ($button, $locator) {

--- a/src/Behat/FlexibleMink/PseudoInterface/FlexibleContextInterface.php
+++ b/src/Behat/FlexibleMink/PseudoInterface/FlexibleContextInterface.php
@@ -188,10 +188,11 @@ trait FlexibleContextInterface
      * Warning: Will return the first button if the driver does not support visibility checks.
      *
      * @param  string               $locator The button name.
+     * @param  TraversableElement   $context Element on the page to which button belongs.
      * @throws ExpectationException If a visible button was not found.
      * @return NodeElement          The button.
      */
-    abstract public function scrollToButton($locator);
+    abstract public function scrollToButton($locator, TraversableElement $context = null);
 
     /**
      * Finds the first matching visible button on the page.
@@ -378,10 +379,11 @@ trait FlexibleContextInterface
      * buttons are pressed and that it waits for the button to be available with a max time limit.
      *
      * @see MinkContext::pressButton
-     * @param  string               $button button id, inner text, value or alt
+     * @param  string               $button  button id, inner text, value or alt
+     * @param  TraversableElement   $context Element on the page to which button belongs.
      * @throws ExpectationException If a visible button field is not found.
      */
-    abstract public function pressButton($button);
+    abstract public function pressButton($button, TraversableElement $context = null);
 
     /**
      * Scrolls the window to the top, bottom, left, right (or any valid combination thereof) of the page body.

--- a/tests/Behat/FlexibleMink/Context/FlexibleContext/AssertPressButtonTest.php
+++ b/tests/Behat/FlexibleMink/Context/FlexibleContext/AssertPressButtonTest.php
@@ -5,7 +5,7 @@ use Behat\Mink\Exception\ExpectationException;
 use PHPUnit_Framework_MockObject_MockObject;
 
 /**
- * This Class tests the pressButton function in FlexibleContext
+ * This Class tests the pressButton function in FlexibleContext.
  */
 class AssertPressButtonTest extends FlexibleContextTest
 {
@@ -25,7 +25,7 @@ class AssertPressButtonTest extends FlexibleContextTest
 
     public function testThrowsExceptionWhenButtonIsDisabled()
     {
-        /** @var NodeElement|PHPUnit_Framework_MockObject_MockObject */
+        /* @var NodeElement|PHPUnit_Framework_MockObject_MockObject */
         $this->button = $this->getMock(NodeElement::class, ['getAttribute'], ['', $this->sessionMock]);
         $this->flexible_context->method('scrollToButton')->willReturn($this->button);
         $this->button->method('getAttribute')->willReturn('disabled');
@@ -35,12 +35,11 @@ class AssertPressButtonTest extends FlexibleContextTest
 
     public function testSuccessfulButtonPress()
     {
-        /** @var NodeElement|PHPUnit_Framework_MockObject_MockObject */
-        $this->button = $this->getMock(NodeElement::class, ['getAttribute','press'], ['', $this->sessionMock]);
+        /* @var NodeElement|PHPUnit_Framework_MockObject_MockObject */
+        $this->button = $this->getMock(NodeElement::class, ['getAttribute', 'press'], ['', $this->sessionMock]);
         $this->flexible_context->method('scrollToButton')->willReturn($this->button);
         $this->button->method('getAttribute')->willReturn('enabled');
         $this->button->method('press');
         $this->flexible_context->pressButton($this->locator);
     }
-
 }

--- a/tests/Behat/FlexibleMink/Context/FlexibleContext/AssertPressButtonTest.php
+++ b/tests/Behat/FlexibleMink/Context/FlexibleContext/AssertPressButtonTest.php
@@ -1,0 +1,46 @@
+<?php namespace Tests\Behat\FlexibleMink\Context\FlexibleContext;
+
+use Behat\Mink\Element\NodeElement;
+use Behat\Mink\Exception\ExpectationException;
+use PHPUnit_Framework_MockObject_MockObject;
+
+/**
+ * This Class tests the pressButton function in FlexibleContext
+ */
+class AssertPressButtonTest extends FlexibleContextTest
+{
+    protected $locator = 'button';
+
+    /** @var NodeElement|PHPUnit_Framework_MockObject_MockObject */
+    protected $button;
+
+    public function testIfExceptionThrownInScrollToButtonFunctionBubblesUP()
+    {
+        $this->setExpectedException(ExpectationException::class, "No visible button found for '$this->locator'");
+        /** @var ExpectationException $expectation_exception */
+        $expectation_exception = $this->getMock(ExpectationException::class, [], ["No visible button found for '$this->locator'", $this->sessionMock]);
+        $this->flexible_context->method('scrollToButton')->willThrowException($expectation_exception);
+        $this->flexible_context->pressButton($this->locator);
+    }
+
+    public function testThrowsExceptionWhenButtonIsDisabled()
+    {
+        /** @var NodeElement|PHPUnit_Framework_MockObject_MockObject */
+        $this->button = $this->getMock(NodeElement::class, ['getAttribute'], ['', $this->sessionMock]);
+        $this->flexible_context->method('scrollToButton')->willReturn($this->button);
+        $this->button->method('getAttribute')->willReturn('disabled');
+        $this->setExpectedException(ExpectationException::class, "Unable to press disabled button '$this->locator'.");
+        $this->flexible_context->pressButton($this->locator);
+    }
+
+    public function testSuccessfulButtonPress()
+    {
+        /** @var NodeElement|PHPUnit_Framework_MockObject_MockObject */
+        $this->button = $this->getMock(NodeElement::class, ['getAttribute','press'], ['', $this->sessionMock]);
+        $this->flexible_context->method('scrollToButton')->willReturn($this->button);
+        $this->button->method('getAttribute')->willReturn('enabled');
+        $this->button->method('press');
+        $this->flexible_context->pressButton($this->locator);
+    }
+
+}

--- a/tests/Behat/FlexibleMink/Context/FlexibleContext/AssertPressButtonTest.php
+++ b/tests/Behat/FlexibleMink/Context/FlexibleContext/AssertPressButtonTest.php
@@ -25,15 +25,15 @@ class AssertPressButtonTest extends FlexibleContextTest
 
     public function testThrowsExceptionWhenButtonIsDisabled()
     {
-        $this->initCommonSteps(['getAttribute'],'disabled');
+        $this->initCommonSteps(['getAttribute'], 'disabled');
         $this->setExpectedException(ExpectationException::class, "Unable to press disabled button '$this->locator'.");
         $this->flexible_context->pressButton($this->locator);
     }
 
     public function testThrowsExceptionWhenButtonIsNotVisibleInViewPort()
     {
-        $this->initCommonSteps(['getAttribute'],null);
-        $exceptionMessage = "The following element was expected to be visible in viewport, but was not:";
+        $this->initCommonSteps(['getAttribute'], null);
+        $exceptionMessage = 'The following element was expected to be visible in viewport, but was not:';
         $this->mockAndSetExpectationException($exceptionMessage);
         $this->flexible_context->method('assertNodeElementVisibleInViewport')->willThrowException($this->expectation_exception);
         $this->flexible_context->pressButton($this->locator);
@@ -41,7 +41,7 @@ class AssertPressButtonTest extends FlexibleContextTest
 
     public function testSuccessfulButtonPress()
     {
-        $this->initCommonSteps(['getAttribute', 'press'],null);
+        $this->initCommonSteps(['getAttribute', 'press'], null);
         $this->flexible_context->method('assertNodeElementVisibleInViewport');
         $this->button->method('press');
         $this->flexible_context->pressButton($this->locator);
@@ -61,8 +61,8 @@ class AssertPressButtonTest extends FlexibleContextTest
     /**
      * This method initializes the common steps to run the tests in this class.
      *
-     * @param array $nodeElementMockMethods
-     * @param $getAttributeReturnValue
+     * @param array  $nodeElementMockMethods   The methods to be mocked
+     * @param string $getAttributeReturnValue  The value that need to be returned when getAttribute method is mocked
      */
     protected function initCommonSteps(array $nodeElementMockMethods, $getAttributeReturnValue)
     {

--- a/tests/Behat/FlexibleMink/Context/FlexibleContext/AssertPressButtonTest.php
+++ b/tests/Behat/FlexibleMink/Context/FlexibleContext/AssertPressButtonTest.php
@@ -61,8 +61,8 @@ class AssertPressButtonTest extends FlexibleContextTest
     /**
      * This method initializes the common steps to run the tests in this class.
      *
-     * @param array  $nodeElementMockMethods   The methods to be mocked
-     * @param string $getAttributeReturnValue  The value that need to be returned when getAttribute method is mocked
+     * @param array  $nodeElementMockMethods  The methods to be mocked
+     * @param string $getAttributeReturnValue The value that need to be returned when getAttribute method is mocked
      */
     protected function initCommonSteps(array $nodeElementMockMethods, $getAttributeReturnValue)
     {

--- a/tests/Behat/FlexibleMink/Context/FlexibleContext/AssertScrollToButtonTest.php
+++ b/tests/Behat/FlexibleMink/Context/FlexibleContext/AssertScrollToButtonTest.php
@@ -1,0 +1,97 @@
+<?php namespace Tests\Behat\FlexibleMink\Context\FlexibleContext;
+
+use Behat\Mink\Element\NodeElement;
+use Behat\Mink\Element\TraversableElement;
+use Behat\Mink\Exception\ExpectationException;
+use PHPUnit_Framework_MockObject_MockObject;
+
+/**
+ * This Class tests the scrollToButton function in FlexibleContext
+ */
+class AssertScrollToButtonTest extends FlexibleContextTest
+{
+    /** @var TraversableElement|PHPUnit_Framework_MockObject_MockObject*/
+    protected $context;
+
+    /** @var NodeElement|PHPUnit_Framework_MockObject_MockObject */
+    protected $element1;
+
+    /** @var NodeElement|PHPUnit_Framework_MockObject_MockObject */
+    protected $element2;
+
+    /** @var NodeElement[] */
+    protected $expectedElements;
+
+    public function setUp()
+    {
+        if(in_array('scrollToButton',$this->flexible_context_mocked_methods)) {
+            unset(
+                $this->flexible_context_mocked_methods[
+                    array_search(
+                        'scrollToButton',
+                        $this->flexible_context_mocked_methods
+                    )
+                ]);
+        }
+        parent::setUp();
+    }
+
+    public function testThrowsExceptionWhenButtonIsNotVisibleInPage()
+    {
+        $locator = 'button';
+        $this->flexible_context->method('fixStepArgument')->willReturn($locator);
+        $this->pageMock->method('findAll')->willReturn([]);
+        $this->setExpectedException(ExpectationException::class, "No visible button found for '$locator'");
+        $this->flexible_context->scrollToButton('button');
+    }
+
+    public function testThrowsExceptionWhenButtonIsNotVisibleInContext()
+    {
+        $locator = 'button';
+        $this->flexible_context->method('fixStepArgument')->willReturn($locator);
+        $this->initContext();
+        $this->context->method('findAll')->willReturn([]);
+        $this->setExpectedException(ExpectationException::class, "No visible button found for '$locator'");
+        $this->flexible_context->scrollToButton('button', $this->context);
+    }
+
+    public function testReturnsFoundButtonInPage()
+    {
+        $this->initElements();
+        $this->flexible_context->method('fixStepArgument')->willReturn('button');
+        $this->pageMock->method('findAll')->willReturn($this->expectedElements);
+        $this->flexible_context->method('scrollWindowToFirstVisibleElement')->willReturn($this->element1);
+        $elements = $this->flexible_context->scrollToButton('button');
+        $this->assertEquals($elements, $this->element1);
+    }
+
+    public function testReturnsFoundButtonInContext()
+    {
+        $this->initElements();
+        $this->flexible_context->method('fixStepArgument')->willReturn('button');
+        $this->initContext();
+        $this->context->method('findAll')->willReturn($this->expectedElements);
+        $this->flexible_context->method('scrollWindowToFirstVisibleElement')->willReturn($this->element1);
+        $elements = $this->flexible_context->scrollToButton('button', $this->context);
+        $this->assertEquals($elements, $this->element1);
+    }
+
+    protected function initElements()
+    {
+        $this->element1 = $this->getMock(NodeElement::class, [], ['', $this->sessionMock]);
+        $this->element2 = $this->getMock(NodeElement::class, [], ['', $this->sessionMock]);
+        $this->expectedElements = [$this->element1, $this->element2];
+    }
+
+    protected function initContext()
+    {
+        $this->context = $this->getMockForAbstractClass(
+            TraversableElement::class, [$this->sessionMock],
+            '',
+            true,
+            true,
+            true,
+            ['findAll']
+        );
+    }
+}

--- a/tests/Behat/FlexibleMink/Context/FlexibleContext/AssertScrollToButtonTest.php
+++ b/tests/Behat/FlexibleMink/Context/FlexibleContext/AssertScrollToButtonTest.php
@@ -5,9 +5,7 @@ use Behat\Mink\Element\TraversableElement;
 use Behat\Mink\Exception\ExpectationException;
 use PHPUnit_Framework_MockObject_MockObject;
 
-/**
- * This Class tests the scrollToButton function in FlexibleContext.
- */
+/** This Class tests the scrollToButton function in FlexibleContext. */
 class AssertScrollToButtonTest extends FlexibleContextTest
 {
     /** @var TraversableElement|PHPUnit_Framework_MockObject_MockObject */
@@ -21,6 +19,8 @@ class AssertScrollToButtonTest extends FlexibleContextTest
 
     /** @var NodeElement[] */
     protected $expectedElements;
+
+    protected $locator = 'button';
 
     public function setUp()
     {
@@ -38,44 +38,43 @@ class AssertScrollToButtonTest extends FlexibleContextTest
 
     public function testThrowsExceptionWhenButtonIsNotVisibleInPage()
     {
-        $locator = 'button';
-        $this->flexible_context->method('fixStepArgument')->willReturn($locator);
+        $this->flexible_context->method('fixStepArgument')->willReturn($this->locator);
         $this->pageMock->method('findAll')->willReturn([]);
-        $this->setExpectedException(ExpectationException::class, "No visible button found for '$locator'");
-        $this->flexible_context->scrollToButton('button');
+        $this->setExpectedException(ExpectationException::class, "No visible button found for '$this->locator'");
+        $this->flexible_context->scrollToButton($this->locator);
     }
 
     public function testThrowsExceptionWhenButtonIsNotVisibleInContext()
     {
-        $locator = 'button';
-        $this->flexible_context->method('fixStepArgument')->willReturn($locator);
-        $this->initContext();
+        $this->flexible_context->method('fixStepArgument')->willReturn($this->locator);
+        $this->mockContext();
         $this->context->method('findAll')->willReturn([]);
-        $this->setExpectedException(ExpectationException::class, "No visible button found for '$locator'");
-        $this->flexible_context->scrollToButton('button', $this->context);
+        $this->setExpectedException(ExpectationException::class, "No visible button found for '$this->locator'");
+        $this->flexible_context->scrollToButton('$this->locator', $this->context);
     }
 
     public function testReturnsFoundButtonInPage()
     {
         $this->initElements();
-        $this->flexible_context->method('fixStepArgument')->willReturn('button');
+        $this->flexible_context->method('fixStepArgument')->willReturn($this->locator);
         $this->pageMock->method('findAll')->willReturn($this->expectedElements);
         $this->flexible_context->method('scrollWindowToFirstVisibleElement')->willReturn($this->element1);
-        $elements = $this->flexible_context->scrollToButton('button');
+        $elements = $this->flexible_context->scrollToButton($this->locator);
         $this->assertEquals($elements, $this->element1);
     }
 
     public function testReturnsFoundButtonInContext()
     {
         $this->initElements();
-        $this->flexible_context->method('fixStepArgument')->willReturn('button');
-        $this->initContext();
+        $this->flexible_context->method('fixStepArgument')->willReturn($this->locator);
+        $this->mockContext();
         $this->context->method('findAll')->willReturn($this->expectedElements);
         $this->flexible_context->method('scrollWindowToFirstVisibleElement')->willReturn($this->element1);
-        $elements = $this->flexible_context->scrollToButton('button', $this->context);
+        $elements = $this->flexible_context->scrollToButton($this->locator, $this->context);
         $this->assertEquals($elements, $this->element1);
     }
 
+    /** This method Initializes the elements to be used as return values. */
     protected function initElements()
     {
         $this->element1 = $this->getMock(NodeElement::class, [], ['', $this->sessionMock]);
@@ -83,7 +82,8 @@ class AssertScrollToButtonTest extends FlexibleContextTest
         $this->expectedElements = [$this->element1, $this->element2];
     }
 
-    protected function initContext()
+    /** This method mocks the Context to be passed as an parameter to scrollToButton function. */
+    protected function mockContext()
     {
         $this->context = $this->getMockForAbstractClass(
             TraversableElement::class, [$this->sessionMock],

--- a/tests/Behat/FlexibleMink/Context/FlexibleContext/AssertScrollToButtonTest.php
+++ b/tests/Behat/FlexibleMink/Context/FlexibleContext/AssertScrollToButtonTest.php
@@ -6,11 +6,11 @@ use Behat\Mink\Exception\ExpectationException;
 use PHPUnit_Framework_MockObject_MockObject;
 
 /**
- * This Class tests the scrollToButton function in FlexibleContext
+ * This Class tests the scrollToButton function in FlexibleContext.
  */
 class AssertScrollToButtonTest extends FlexibleContextTest
 {
-    /** @var TraversableElement|PHPUnit_Framework_MockObject_MockObject*/
+    /** @var TraversableElement|PHPUnit_Framework_MockObject_MockObject */
     protected $context;
 
     /** @var NodeElement|PHPUnit_Framework_MockObject_MockObject */
@@ -24,7 +24,7 @@ class AssertScrollToButtonTest extends FlexibleContextTest
 
     public function setUp()
     {
-        if(in_array('scrollToButton',$this->flexible_context_mocked_methods)) {
+        if (in_array('scrollToButton', $this->flexible_context_mocked_methods)) {
             unset(
                 $this->flexible_context_mocked_methods[
                     array_search(

--- a/tests/Behat/FlexibleMink/Context/FlexibleContext/FlexibleContextTest.php
+++ b/tests/Behat/FlexibleMink/Context/FlexibleContext/FlexibleContextTest.php
@@ -25,7 +25,7 @@ abstract class FlexibleContextTest extends PHPUnit_Framework_TestCase
         'fixStepArgument',
         'scrollWindowToFirstVisibleElement',
         'assertNodeElementVisibleInViewport',
-        'scrollToButton'
+        'scrollToButton',
     ];
 
     /**

--- a/tests/Behat/FlexibleMink/Context/FlexibleContext/FlexibleContextTest.php
+++ b/tests/Behat/FlexibleMink/Context/FlexibleContext/FlexibleContextTest.php
@@ -20,7 +20,13 @@ abstract class FlexibleContextTest extends PHPUnit_Framework_TestCase
     /** @var FlexibleContext|PHPUnit_Framework_MockObject_MockObject */
     protected $flexible_context;
 
-    protected $flexible_context_mocked_methods = ['getSession', 'fixStepArgument', 'scrollWindowToFirstVisibleElement', 'scrollToButton'];
+    protected $flexible_context_mocked_methods = [
+        'getSession',
+        'fixStepArgument',
+        'scrollWindowToFirstVisibleElement',
+        'assertNodeElementVisibleInViewport',
+        'scrollToButton'
+    ];
 
     /**
      * {@inheritdoc}

--- a/tests/Behat/FlexibleMink/Context/FlexibleContext/FlexibleContextTest.php
+++ b/tests/Behat/FlexibleMink/Context/FlexibleContext/FlexibleContextTest.php
@@ -20,12 +20,14 @@ abstract class FlexibleContextTest extends PHPUnit_Framework_TestCase
     /** @var FlexibleContext|PHPUnit_Framework_MockObject_MockObject */
     protected $flexible_context;
 
+    protected $flexible_context_mocked_methods = ['getSession','fixStepArgument','scrollWindowToFirstVisibleElement', 'scrollToButton'];
+
     /**
      * {@inheritdoc}
      */
     public function setUp()
     {
-        $this->flexible_context = $this->getMock(FlexibleContext::class, ['getSession']);
+        $this->flexible_context = $this->getMock(FlexibleContext::class, $this->flexible_context_mocked_methods);
         $this->sessionMock = $this->getMock(Session::class, ['getPage'], [], '', false);
         $this->pageMock = $this->getMock(DocumentElement::class, ['findAll'], [], '', false);
         $this->flexible_context->method('getSession')->willReturn($this->sessionMock);

--- a/tests/Behat/FlexibleMink/Context/FlexibleContext/FlexibleContextTest.php
+++ b/tests/Behat/FlexibleMink/Context/FlexibleContext/FlexibleContextTest.php
@@ -20,7 +20,7 @@ abstract class FlexibleContextTest extends PHPUnit_Framework_TestCase
     /** @var FlexibleContext|PHPUnit_Framework_MockObject_MockObject */
     protected $flexible_context;
 
-    protected $flexible_context_mocked_methods = ['getSession','fixStepArgument','scrollWindowToFirstVisibleElement', 'scrollToButton'];
+    protected $flexible_context_mocked_methods = ['getSession', 'fixStepArgument', 'scrollWindowToFirstVisibleElement', 'scrollToButton'];
 
     /**
      * {@inheritdoc}


### PR DESCRIPTION
- This changes were made to support one of my requirements in another PR where I making sure that the button I'm clicking on belongs to Element ( dialogue box, etc) that I'm intended to click. So, with these changes, we can now be sure and confident that the button we click is the one which we wanted to.   
- As it is by default null, it wont effect other test scenarios.  