### PR TITLE
Adding TraversableElement as parameter in pressButton and ScrollToButton

### DIFF
--- a/src/Medology/Behat/Mink/FlexibleContext.php
+++ b/src/Medology/Behat/Mink/FlexibleContext.php
@@ -581,16 +581,18 @@ class FlexibleContext extends MinkContext
      * Finds the first matching visible button on the page, scrolling to it if necessary.
      *
      * @param  string                           $locator The button name.
+     * @param  TraversableElement               $context Element on the page to which button belongs.
      * @throws DriverException                  When the operation cannot be performed.
      * @throws ExpectationException             If a visible button was not found.
      * @throws UnsupportedDriverActionException When operation not supported by the driver.
      * @return NodeElement                      The button.
      */
-    public function scrollToButton($locator)
+    public function scrollToButton($locator, TraversableElement $context = null)
     {
         $locator = $this->fixStepArgument($locator);
 
-        $buttons = $this->getSession()->getPage()->findAll('named', ['button', $locator]);
+        $context = $context ? $context : $this->getSession()->getPage();
+        $buttons = $context->findAll('named', ['button', $locator]);
 
         if (!($element = $this->scrollWindowToFirstVisibleElement($buttons))) {
             throw new ExpectationException("No visible button found for '$locator'", $this->getSession());
@@ -1201,14 +1203,15 @@ class FlexibleContext extends MinkContext
      * This method overrides the base method to ensure that only visible & enabled buttons are pressed.
      *
      * @param  string                           $locator button id, inner text, value or alt
+     * @param  TraversableElement               $context Element on the page to which button belongs.
      * @throws DriverException                  When the operation cannot be performed.
      * @throws ExpectationException             If a visible button field is not found.
      * @throws UnsupportedDriverActionException When operation not supported by the driver.
      * @throws ExpectationException             If Button is found but not visible in the viewport.
      */
-    public function pressButton($locator)
+    public function pressButton($locator, TraversableElement $context = null)
     {
-        $button = $this->wait->scrollToButton($locator);
+        $button = $this->wait->scrollToButton($locator, $context);
 
         /* @noinspection PhpUnhandledExceptionInspection */
         Spinner::waitFor(function () use ($button, $locator) {

--- a/tests/Medology/Behat/Mink/FlexibleContext/FlexibleContextTest.php
+++ b/tests/Medology/Behat/Mink/FlexibleContext/FlexibleContextTest.php
@@ -20,12 +20,14 @@ abstract class FlexibleContextTest extends PHPUnit_Framework_TestCase
     /** @var FlexibleContext|PHPUnit_Framework_MockObject_MockObject */
     protected $flexible_context;
 
+    protected $flexible_context_mocked_methods = ['getSession'];
+
     /**
      * {@inheritdoc}
      */
     public function setUp()
     {
-        $this->flexible_context = $this->createPartialMock(FlexibleContext::class, ['getSession']);
+        $this->flexible_context = $this->createPartialMock(FlexibleContext::class, $this->flexible_context_mocked_methods);
         $this->sessionMock = $this->createMock(Session::class);
         $this->pageMock = $this->createMock(DocumentElement::class);
         $this->flexible_context->method('getSession')->willReturn($this->sessionMock);

--- a/tests/Medology/Behat/Mink/FlexibleContext/ScrollToButtonTest.php
+++ b/tests/Medology/Behat/Mink/FlexibleContext/ScrollToButtonTest.php
@@ -1,0 +1,108 @@
+<?php namespace Tests\Medology\Behat\Mink\FlexibleContext;
+
+use Behat\Mink\Element\NodeElement;
+use Behat\Mink\Element\TraversableElement;
+use Behat\Mink\Exception\ExpectationException;
+use PHPUnit_Framework_MockObject_MockObject;
+
+class ScrollToButtonTest extends FlexibleContextTest
+{
+    /** @var TraversableElement|PHPUnit_Framework_MockObject_MockObject */
+    protected $context;
+
+    /** @var NodeElement|PHPUnit_Framework_MockObject_MockObject */
+    protected $element1;
+
+    /** @var NodeElement|PHPUnit_Framework_MockObject_MockObject */
+    protected $element2;
+
+    /** @var NodeElement[] */
+    protected $expectedElements;
+
+    protected $locator = 'button';
+
+    public function setUp()
+    {
+        $this->flexible_context_mocked_methods = [];
+        array_push(
+            $this->flexible_context_mocked_methods,
+            'getSession',
+            'fixStepArgument',
+            'scrollWindowToFirstVisibleElement'
+        );
+
+        parent::setUp();
+    }
+
+    public function testThrowsExceptionWhenButtonIsNotVisibleInPage()
+    {
+        $this->flexible_context->method('fixStepArgument')->willReturn($this->locator);
+        $this->pageMock->method('findAll')->willReturn([]);
+        $this->createAndExpectExpectationException("No visible button found for '$this->locator'");
+        $this->flexible_context->scrollToButton($this->locator);
+    }
+
+    public function testThrowsExceptionWhenButtonIsNotVisibleInContext()
+    {
+        $this->flexible_context->method('fixStepArgument')->willReturn($this->locator);
+        $this->mockContext();
+        $this->context->method('findAll')->willReturn([]);
+
+        $this->createAndExpectExpectationException("No visible button found for '$this->locator'");
+        $this->flexible_context->scrollToButton('$this->locator', $this->context);
+    }
+
+    public function testReturnsFoundButtonInPage()
+    {
+        $this->initElements();
+        $this->flexible_context->method('fixStepArgument')->willReturn($this->locator);
+        $this->pageMock->method('findAll')->willReturn($this->expectedElements);
+        $this->flexible_context->method('scrollWindowToFirstVisibleElement')->willReturn($this->element1);
+        $elements = $this->flexible_context->scrollToButton($this->locator);
+        $this->assertEquals($elements, $this->element1);
+    }
+
+    public function testReturnsFoundButtonInContext()
+    {
+        $this->initElements();
+        $this->flexible_context->method('fixStepArgument')->willReturn($this->locator);
+        $this->mockContext();
+        $this->context->method('findAll')->willReturn($this->expectedElements);
+        $this->flexible_context->method('scrollWindowToFirstVisibleElement')->willReturn($this->element1);
+        $elements = $this->flexible_context->scrollToButton($this->locator, $this->context);
+        $this->assertEquals($elements, $this->element1);
+    }
+
+    /** This method Initializes the elements to be used as return values. */
+    protected function initElements()
+    {
+        $this->element1 = $this->createPartialMock(NodeElement::class, []);
+        $this->element2 = $this->createPartialMock(NodeElement::class, []);
+        $this->expectedElements = [$this->element1, $this->element2];
+    }
+
+    /** This method mocks the Context to be passed as an parameter to scrollToButton function. */
+    protected function mockContext()
+    {
+        $this->context = $this->getMockForAbstractClass(
+            TraversableElement::class, [$this->sessionMock],
+            '',
+            true,
+            true,
+            true,
+            ['findAll']
+        );
+    }
+
+    /**
+     * This method will create and expect the ExpectationException.
+     *
+     * @param string $exceptionMessage The message while the exception is thrown
+     */
+    protected function createAndExpectExpectationException($exceptionMessage)
+    {
+        $exception = new ExpectationException($exceptionMessage, $this->sessionMock);
+        $this->expectException(get_class($exception));
+        $this->expectExceptionMessage($exception->getMessage());
+    }
+}


### PR DESCRIPTION
updating this changes to v2.0 because these changes are  already updated in v1.0 

## Problem
- we are not sure whether we are clicking the button we intended to. 

## Cause
- pressButton function finds the button with name provided and presses it, without knowing whether we are clicking the right button. 

## Fix
- Fix is to introduce a new parameter TraversableElement, (which will have reference to the element i.e., modal/alert etc) to pressButton and scrolToButton functions. We can now be sure that button we are pressing is right button.  
- As the parameter is by default null, it wont effect other test scenarios.