### PR TITLE
Issue#1035 - Assert Canonical Tag Link

### DIFF
--- a/features/assertLinkLocation.feature
+++ b/features/assertLinkLocation.feature
@@ -1,8 +1,7 @@
-@clearAlertsWhenFinished
-Feature: Alert context
-  In order to ensure that JavaScript alerts work as expected
+Feature: Link Contect
+  In order to ensure that Canonical Links are present
   As a developer
-  I need to be able to assert various states of alerts
+  I need to be able to assert that the canonical tag contains the proper url
 
   Scenario: Link Location
      When I am on "/assert-link-location.html"

--- a/features/assertLinkLocation.feature
+++ b/features/assertLinkLocation.feature
@@ -1,0 +1,9 @@
+@clearAlertsWhenFinished
+Feature: Alert context
+  In order to ensure that JavaScript alerts work as expected
+  As a developer
+  I need to be able to assert various states of alerts
+
+  Scenario: Link Location
+     When I am on "/assert-link-location.html"
+     Then the canonical tag should point to "http://localhost.local/testing"

--- a/src/Behat/FlexibleMink/Context/FlexibleContext.php
+++ b/src/Behat/FlexibleMink/Context/FlexibleContext.php
@@ -1229,7 +1229,12 @@ JS
         }
 
         foreach ($nodes as $node) {
-            $this->elementHasAttributeValues($node, $attributes);
+            if (!$this->elementHasAttributeValues($node, $attributes)) {
+                throw new ExpectationException(
+                    "Expected  node with '$locator' but found " . print_r($node, true),
+                    $this->getSession()
+                );
+            }
         }
     }
 

--- a/src/Behat/FlexibleMink/Context/FlexibleContext.php
+++ b/src/Behat/FlexibleMink/Context/FlexibleContext.php
@@ -30,6 +30,7 @@ class FlexibleContext extends MinkContext
     use AlertContext;
     use ContainerContext;
     use JavaScriptContext;
+    use LinkContext;
     use SpinnerContext;
     use StoreContext;
     use TableContext;
@@ -1211,6 +1212,25 @@ JS
         }
 
         return true;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function assertNodesHaveAttributeValues($locator, array $attributes, $selector = 'named', $occurrences = null)
+    {
+        /** @var NodeElement[] $links */
+        $nodes = $this->getSession()->getPage()->findAll($selector, $locator);
+
+        if (!count($nodes)) {
+            throw new ExpectationException("No node elements were found on the page using '$locator'", $this->getSession());
+        } elseif ($occurrences && count($nodes) != $occurrences) {
+            throw new ExpectationException("Expected $occurrences nodes with '$locator' but found " . count($nodes), $this->getSession());
+        }
+
+        foreach ($nodes as $node) {
+            $this->elementHasAttributeValues($node, $attributes);
+        }
     }
 
     /**

--- a/src/Behat/FlexibleMink/Context/LinkContext.php
+++ b/src/Behat/FlexibleMink/Context/LinkContext.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Behat\FlexibleMink\Context;
+
+use Behat\FlexibleMink\PseudoInterface\FlexibleContextInterface;
+use Behat\FlexibleMink\PseudoInterface\LinkContextInterface;
+
+trait LinkContext
+{
+    // Implements.
+    use LinkContextInterface;
+    // Depends.
+    use FlexibleContextInterface;
+
+    /**
+     * {@inheritdoc}
+     *
+     * @Then the canonical tag should point to :destination
+     */
+    public function assertCanonicalTagLocation($destination)
+    {
+        $this->waitFor(function () use ($destination) {
+            $this->assertNodesHaveAttributeValues('//link[@rel="canonical"]', ['href' => $destination], 'xpath', 1);
+        });
+    }
+}

--- a/src/Behat/FlexibleMink/Context/LinkContext.php
+++ b/src/Behat/FlexibleMink/Context/LinkContext.php
@@ -5,6 +5,9 @@ namespace Behat\FlexibleMink\Context;
 use Behat\FlexibleMink\PseudoInterface\FlexibleContextInterface;
 use Behat\FlexibleMink\PseudoInterface\LinkContextInterface;
 
+/**
+ * {@inheritdoc}
+ */
 trait LinkContext
 {
     // Implements.

--- a/src/Behat/FlexibleMink/Context/LinkContext.php
+++ b/src/Behat/FlexibleMink/Context/LinkContext.php
@@ -6,7 +6,7 @@ use Behat\FlexibleMink\PseudoInterface\FlexibleContextInterface;
 use Behat\FlexibleMink\PseudoInterface\LinkContextInterface;
 
 /**
- * {@inheritdoc}
+ * Adds all the methods to handle links.
  */
 trait LinkContext
 {

--- a/src/Behat/FlexibleMink/PseudoInterface/FlexibleContextInterface.php
+++ b/src/Behat/FlexibleMink/PseudoInterface/FlexibleContextInterface.php
@@ -134,6 +134,20 @@ trait FlexibleContextInterface
     abstract public function assertElementNotContainsText($element, $text);
 
     /**
+     * Asserts that all nodes have the specified attribute value.
+     *
+     * @param  string                           $locator     The attribute locator of the node element.
+     * @param  array                            $attributes  A key value paid of the attribute and value the nodes
+     *                                                       should contain
+     * @param  string                           $selector    The selector to use to find the node.
+     * @param  null                             $occurrences The number of time the node element should be found.
+     * @throws DriverException                  When the operation cannot be done
+     * @throws ExpectationException             If the nodes attributes do not match
+     * @throws UnsupportedDriverActionException When operation not supported by the driver
+     */
+    abstract public function assertNodesHaveAttributeValues($locator, array $attributes, $selector = 'named', $occurrences = null);
+
+    /**
      * Clicks a visible link with specified id|title|alt|text.
      *
      * This method overrides the MinkContext::clickLink() default behavior for clickLink to ensure that only visible

--- a/src/Behat/FlexibleMink/PseudoInterface/LinkContextInterface.php
+++ b/src/Behat/FlexibleMink/PseudoInterface/LinkContextInterface.php
@@ -12,8 +12,8 @@ trait LinkContextInterface
     /**
      * Asserts that the canonical tag points to the given location.
      *
-     * @param  string               $destination The location the link should be pointint to.
-     * @throws ExpectationException
+     * @param  string               $destination The location the link should be pointing to.
+     * @throws ExpectationException When the canonical tag does not contain the given destination.
      */
     abstract public function assertCanonicalTagLocation($destination);
 }

--- a/src/Behat/FlexibleMink/PseudoInterface/LinkContextInterface.php
+++ b/src/Behat/FlexibleMink/PseudoInterface/LinkContextInterface.php
@@ -5,7 +5,7 @@ namespace Behat\FlexibleMink\PseudoInterface;
 use Behat\Mink\Exception\ExpectationException;
 
 /**
- * Pseudo interface for tracking the methods of the ContainerContext.
+ * Pseudo interface for tracking the methods of the LinkContext.
  */
 trait LinkContextInterface
 {

--- a/src/Behat/FlexibleMink/PseudoInterface/LinkContextInterface.php
+++ b/src/Behat/FlexibleMink/PseudoInterface/LinkContextInterface.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Behat\FlexibleMink\PseudoInterface;
+
+use Behat\Mink\Exception\ExpectationException;
+
+/**
+ * Pseudo interface for tracking the methods of the ContainerContext.
+ */
+trait LinkContextInterface
+{
+    /**
+     * Asserts that the canonical tag points to the given location.
+     *
+     * @param  string               $destination The location the link should be pointint to.
+     * @throws ExpectationException
+     */
+    abstract public function assertCanonicalTagLocation($destination);
+}

--- a/web/assert-link-location.html
+++ b/web/assert-link-location.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <title>Text in Element for Flexible Mink</title>
+    <link rel="canonical" href="http://localhost.local/testing" />
+</head>
+
+<body>
+    <div id="emptyDiv"></div>
+    <div id="divWithText">This is a div</div>
+</body>
+
+</html>


### PR DESCRIPTION
For #1035

### Issue:
For Marketing purposes we need to be able to assert canonical tag location.

### Solution:
Add function to assert canonical tag exist and contains proper link.