### PR TITLE
Fix pull approve yaml configuration on 1.0

### DIFF
--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -3,7 +3,7 @@ extends: "https://api.github.com/repos/medology/Scripts/contents/Pull%20Approve/
 pullapprove_conditions:
   - "state == 'open'"
   - "'[DO NOT REVIEW]' not in title"
-  - "base.ref == '2.0'"
+  - "base.ref == '1.0'"
   - "'ci/circleci: build' in statuses.succeeded or 'Force Review' in labels"
   - "'ci/circleci: build-php5' in statuses.succeeded or 'Force Review' in labels"
   - "'ci/circleci: test' in statuses.succeeded or 'Force Review' in labels"

--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -1,9 +1,9 @@
 version: 3
 extends: "https://api.github.com/repos/medology/Scripts/contents/Pull%20Approve/base.pullapprove.yml?ref=master"
 pullapprove_conditions:
-  - "base.ref == '1.0'"
-  - "site == 'open'"
+  - "state == 'open'"
   - "'[DO NOT REVIEW]' not in title"
+  - "base.ref == '2.0'"
   - "'ci/circleci: build' in statuses.succeeded or 'Force Review' in labels"
   - "'ci/circleci: build-php5' in statuses.succeeded or 'Force Review' in labels"
   - "'ci/circleci: test' in statuses.succeeded or 'Force Review' in labels"


### PR DESCRIPTION
Rename the invalid parameter to site to state. "state" is a valid(and tested) parameter.
Add a condition to only assign reviewers if the PR is open.

Bugman is currently disabled on flexible mink. This PR is blocking the 1.0 branch from getting reviewers.