### PR TITLE
Issue#1035 - Assert Canonical Tag

### DIFF
--- a/behat.yml
+++ b/behat.yml
@@ -9,6 +9,7 @@ default:
         - Medology\Behat\Mink\AlertContext
         - Medology\Behat\Mink\FlexibleContext
         - Medology\Behat\Mink\JavaScriptContext
+        - Medology\Behat\Mink\LinkContext
         - Medology\Behat\Mink\QualityAssurance
         - Medology\Behat\Mink\ScreenShotContext
         - Medology\Behat\Mink\TableContext

--- a/features/FlexibleContext/assertLinkLocation.feature
+++ b/features/FlexibleContext/assertLinkLocation.feature
@@ -1,0 +1,8 @@
+Feature: Link Context
+  In order to ensure that Canonical Links are present
+  As a developer
+  I need to be able to assert that the canonical tag contains the proper url
+
+  Scenario: Link Location
+    When I am on "/assert-link-location.html"
+    Then the canonical tag should point to "http://localhost.local/testing"

--- a/src/Medology/Behat/Mink/FlexibleContext.php
+++ b/src/Medology/Behat/Mink/FlexibleContext.php
@@ -1273,6 +1273,37 @@ class FlexibleContext extends MinkContext
     }
 
     /**
+     * Asserts that all nodes have the specified attribute value.
+     *
+     * @param  string                           $locator     The attribute locator of the node element.
+     * @param  array                            $attributes  A key value paid of the attribute and value the nodes
+     *                                                       should contain
+     * @param  string                           $selector    The selector to use to find the node.
+     * @param  null                             $occurrences The number of time the node element should be found.
+     * @throws DriverException                  When the operation cannot be done
+     * @throws ExpectationException             If the nodes attributes do not match
+     * @throws UnsupportedDriverActionException When operation not supported by the driver
+     */
+    public function assertNodesHaveAttributeValues($locator, array $attributes, $selector = 'named', $occurrences = null)
+    {
+        /** @var NodeElement[] $links */
+        $nodes = $this->getSession()->getPage()->findAll($selector, $locator);
+        if (!count($nodes)) {
+            throw new ExpectationException("No node elements were found on the page using '$locator'", $this->getSession());
+        } elseif ($occurrences && count($nodes) != $occurrences) {
+            throw new ExpectationException("Expected $occurrences nodes with '$locator' but found " . count($nodes), $this->getSession());
+        }
+        foreach ($nodes as $node) {
+            if (!$this->elementHasAttributeValues($node, $attributes)) {
+                throw new ExpectationException(
+                    "Expected  node with '$locator' but found " . print_r($node, true),
+                    $this->getSession()
+                );
+            }
+        }
+    }
+
+    /**
      * @noinspection PhpDocRedundantThrowsInspection exceptions bubble up from waitFor.
      *
      * {@inheritdoc}

--- a/src/Medology/Behat/Mink/FlexibleContext.php
+++ b/src/Medology/Behat/Mink/FlexibleContext.php
@@ -1290,9 +1290,12 @@ class FlexibleContext extends MinkContext
         $nodes = $this->getSession()->getPage()->findAll($selector, $locator);
         if (!count($nodes)) {
             throw new ExpectationException("No node elements were found on the page using '$locator'", $this->getSession());
-        } elseif ($occurrences && count($nodes) != $occurrences) {
+        }
+
+        if ($occurrences && count($nodes) !== $occurrences) {
             throw new ExpectationException("Expected $occurrences nodes with '$locator' but found " . count($nodes), $this->getSession());
         }
+
         foreach ($nodes as $node) {
             if (!$this->elementHasAttributeValues($node, $attributes)) {
                 throw new ExpectationException(

--- a/src/Medology/Behat/Mink/LinkContext.php
+++ b/src/Medology/Behat/Mink/LinkContext.php
@@ -1,6 +1,4 @@
-<?php
-
-namespace Medology\Behat\Mink;
+<?php namespace Medology\Behat\Mink;
 
 use Behat\Behat\Context\Context;
 use Behat\Mink\Exception\ExpectationException;

--- a/src/Medology/Behat/Mink/LinkContext.php
+++ b/src/Medology/Behat/Mink/LinkContext.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Medology\Behat\Mink;
+
+use Behat\Behat\Context\Context;
+use Behat\Mink\Exception\ExpectationException;
+use Exception;
+use Medology\Spinner;
+
+/**
+ * Context for handling links in the page.
+ *
+ * Class LinkContext
+ */
+class LinkContext implements Context
+{
+    use UsesFlexibleContext;
+
+    /**
+     * Asserts that the canonical tag points to the given location.
+     *
+     * @param  string               $destination The location the link should be pointing to.
+     * @throws Exception            if the assertion did not pass before the timeout was exceeded.
+     * @throws ExpectationException When the canonical tag does not contain the given destination.
+     *
+     * @Then the canonical tag should point to :destination
+     */
+    public function assertCanonicalTagLocation($destination)
+    {
+        /* @noinspection PhpUnhandledExceptionInspection */
+        Spinner::waitFor(function () use ($destination) {
+            $this->flexibleContext->assertNodesHaveAttributeValues(
+                '//link[@rel="canonical"]',
+                ['href' => $destination],
+                'xpath',
+                1
+            );
+        });
+    }
+}

--- a/web/assert-link-location.html
+++ b/web/assert-link-location.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <title>Text in Element for Flexible Mink</title>
+    <link rel="canonical" href="http://localhost.local/testing" />
+</head>
+
+<body>
+<div id="emptyDiv"></div>
+<div id="divWithText">This is a div</div>
+</body>
+
+</html>

--- a/web/assert-link-location.html
+++ b/web/assert-link-location.html
@@ -3,12 +3,12 @@
 
 <head>
     <title>Text in Element for Flexible Mink</title>
-    <link rel="canonical" href="http://localhost.local/testing" />
+    <link rel="canonical" href="http://localhost.local/testing"/>
 </head>
 
 <body>
-<div id="emptyDiv"></div>
-<div id="divWithText">This is a div</div>
+    <div id="emptyDiv"></div>
+    <div id="divWithText">This is a div</div>
 </body>
 
 </html>


### PR DESCRIPTION
Add the same function to 2.0 flexible mink.

Add test to assert canonical tag exist and contains the proper link.
add appropriate needed function to assert any node contain attribute values.