### PR TITLE
Move assertJavascriptVariableEquals to FlexibleContext

### DIFF
--- a/src/Behat/FlexibleMink/Context/FlexibleContext.php
+++ b/src/Behat/FlexibleMink/Context/FlexibleContext.php
@@ -1535,4 +1535,31 @@ JS
 
         return $driver;
     }
+
+    /**
+     * Asserts a javascript variable's value matches its expected value. This method is necessitated by
+     * the fact that assertJavascriptVariable() doesn't use a waitFor().
+     *
+     * @param  string               $variableName  The name of the JS variable
+     * @param  string               $expectedValue The expected value of the JS variable
+     * @throws ExpectationException If the JS variable value doesn't match the expected value
+     * @throws Exception
+     *
+     * @Then the javascript variable :variableName should be set to :expectedValue
+     */
+    public function assertJavascriptVariableEquals($variableName, $expectedValue)
+    {
+        $this->waitFor(function () use ($variableName, $expectedValue) {
+            $returnedValue = $this->getSession()->evaluateScript(
+                'return ' . $variableName . ';'
+            );
+
+            if ($returnedValue != $expectedValue) {
+                throw new ExpectationException(
+                    "Expected \"$expectedValue\" but got \"$returnedValue\"",
+                    $this->getSession()
+                );
+            }
+        });
+    }
 }


### PR DESCRIPTION
For https://github.com/Medology/www.healthlabs.com/issues/990
This PR will add the `javascriptVariableAssertion` which can assert if a javascript variable exist in the browser.