### PR TITLE
Scroll the page smoothly

### DIFF
--- a/src/Behat/FlexibleMink/Context/FlexibleContext.php
+++ b/src/Behat/FlexibleMink/Context/FlexibleContext.php
@@ -1074,7 +1074,6 @@ class FlexibleContext extends MinkContext
      * @param string $whereToScroll   The direction to scroll the page. Can be any valid combination of
      *                                "top", "bottom", "left" and "right". e.g. "top", "top right", but not "top bottom"
      * @param bool   $useSmoothScroll Use the smooth scrolling behavior if the browser supports it.
-     *
      */
     public function scrollWindowToBody(string $whereToScroll, bool $useSmoothScroll = false): void
     {

--- a/src/Behat/FlexibleMink/Context/FlexibleContext.php
+++ b/src/Behat/FlexibleMink/Context/FlexibleContext.php
@@ -1068,10 +1068,10 @@ class FlexibleContext extends MinkContext
     /**
      * {@inheritdoc}
      *
-     * @When /^(?:I |)scroll to the (?P<where>[ a-z]+) of the page$/
-     * @Given /^the page is scrolled to the (?P<where>top|bottom)$/
+     * @When /^(?:I |)scroll to the (?P<where>[ a-z]+) of the page(?:(?P<smooth> smoothly)|)$/
+     * @Given /^the page is scrolled to the (?P<where>top|bottom)(?:(?P<smooth> smoothly)|)$/
      */
-    public function scrollWindowToBody($where)
+    public function scrollWindowToBody($where, $smooth = false)
     {
         // horizontal scroll
         $x = 'window.scrollX';
@@ -1093,7 +1093,7 @@ class FlexibleContext extends MinkContext
 
         $supportsSmoothScroll = $this->getSession()->evaluateScript("'scrollBehavior' in document.documentElement.style");
 
-        if ($supportsSmoothScroll) {
+        if ($smooth && $supportsSmoothScroll) {
             $this->getSession()->executeScript("window.scrollTo({top: $y, left: $x, behavior: 'smooth'})");
         } else {
             $this->getSession()->executeScript("window.scrollTo($x, $y)");

--- a/src/Behat/FlexibleMink/Context/FlexibleContext.php
+++ b/src/Behat/FlexibleMink/Context/FlexibleContext.php
@@ -1074,21 +1074,21 @@ class FlexibleContext extends MinkContext
     public function scrollWindowToBody($where)
     {
         // horizontal scroll
+        $x = 'window.scrollX';
+
         if (strpos($where, 'left') !== false) {
             $x = 0;
         } elseif (strpos($where, 'right') !== false) {
             $x = 'document.body.scrollWidth';
-        } else {
-            $x = 'window.scrollX';
         }
 
         // vertical scroll
+        $y = 'window.scrollY';
+
         if (strpos($where, 'top') !== false) {
             $y = 0;
         } elseif (strpos($where, 'bottom') !== false) {
             $y = 'document.body.scrollHeight';
-        } else {
-            $y = 'window.scrollY';
         }
 
         $this->getSession()->executeScript("window.scrollTo({top: $y, left: $x, behavior: 'smooth'})");

--- a/src/Behat/FlexibleMink/Context/FlexibleContext.php
+++ b/src/Behat/FlexibleMink/Context/FlexibleContext.php
@@ -1068,32 +1068,37 @@ class FlexibleContext extends MinkContext
     /**
      * {@inheritdoc}
      *
-     * @When /^(?:I |)scroll to the (?P<where>[ a-z]+) of the page(?:(?P<smooth> smoothly)|)$/
-     * @Given /^the page is scrolled to the (?P<where>top|bottom)(?:(?P<smooth> smoothly)|)$/
+     * @When /^(?:I |)scroll to the (?P<whereToScroll>[ a-z]+) of the page(?:(?P<useSmoothScroll> smoothly)|)$/
+     * @Given /^the page is scrolled to the (?P<whereToScroll>top|bottom)(?:(?P<useSmoothScroll> smoothly)|)$/
+     *
+     * @param string $whereToScroll   The direction to scroll the page. Can be any valid combination of
+     *                                "top", "bottom", "left" and "right". e.g. "top", "top right", but not "top bottom"
+     * @param bool   $useSmoothScroll Use the smooth scrolling behavior if the browser supports it.
+     *
      */
-    public function scrollWindowToBody($where, $smooth = false)
+    public function scrollWindowToBody(string $whereToScroll, bool $useSmoothScroll = false): void
     {
         // horizontal scroll
         $x = 'window.scrollX';
 
-        if (strpos($where, 'left') !== false) {
+        if (strpos($whereToScroll, 'left') !== false) {
             $x = 0;
-        } elseif (strpos($where, 'right') !== false) {
+        } elseif (strpos($whereToScroll, 'right') !== false) {
             $x = 'document.body.scrollWidth';
         }
 
         // vertical scroll
         $y = 'window.scrollY';
 
-        if (strpos($where, 'top') !== false) {
+        if (strpos($whereToScroll, 'top') !== false) {
             $y = 0;
-        } elseif (strpos($where, 'bottom') !== false) {
+        } elseif (strpos($whereToScroll, 'bottom') !== false) {
             $y = 'document.body.scrollHeight';
         }
 
         $supportsSmoothScroll = $this->getSession()->evaluateScript("'scrollBehavior' in document.documentElement.style");
 
-        if ($smooth && $supportsSmoothScroll) {
+        if ($useSmoothScroll && $supportsSmoothScroll) {
             $this->getSession()->executeScript("window.scrollTo({top: $y, left: $x, behavior: 'smooth'})");
         } else {
             $this->getSession()->executeScript("window.scrollTo($x, $y)");

--- a/src/Behat/FlexibleMink/Context/FlexibleContext.php
+++ b/src/Behat/FlexibleMink/Context/FlexibleContext.php
@@ -1091,7 +1091,7 @@ class FlexibleContext extends MinkContext
             $y = 'window.scrollY';
         }
 
-        $this->getSession()->executeScript("window.scrollTo($x, $y)");
+        $this->getSession()->executeScript("window.scrollTo({top: $y, left: $x, behavior: 'smooth'})");
     }
 
     /**

--- a/src/Behat/FlexibleMink/Context/FlexibleContext.php
+++ b/src/Behat/FlexibleMink/Context/FlexibleContext.php
@@ -1078,29 +1078,29 @@ class FlexibleContext extends MinkContext
     public function scrollWindowToBody($whereToScroll, $useSmoothScroll = false)
     {
         // horizontal scroll
-        $x = 'window.scrollX';
+        $scrollHorizontal = 'window.scrollX';
 
         if (strpos($whereToScroll, 'left') !== false) {
-            $x = 0;
+            $scrollHorizontal = 0;
         } elseif (strpos($whereToScroll, 'right') !== false) {
-            $x = 'document.body.scrollWidth';
+            $scrollHorizontal = 'document.body.scrollWidth';
         }
 
         // vertical scroll
-        $y = 'window.scrollY';
+        $scrollVertical = 'window.scrollY';
 
         if (strpos($whereToScroll, 'top') !== false) {
-            $y = 0;
+            $scrollVertical = 0;
         } elseif (strpos($whereToScroll, 'bottom') !== false) {
-            $y = 'document.body.scrollHeight';
+            $scrollVertical = 'document.body.scrollHeight';
         }
 
         $supportsSmoothScroll = $this->getSession()->evaluateScript("'scrollBehavior' in document.documentElement.style");
 
         if ($useSmoothScroll && $supportsSmoothScroll) {
-            $this->getSession()->executeScript("window.scrollTo({top: $y, left: $x, behavior: 'smooth'})");
+            $this->getSession()->executeScript("window.scrollTo({top: $scrollVertical, left: $$scrollHorizontal, behavior: 'smooth'})");
         } else {
-            $this->getSession()->executeScript("window.scrollTo($x, $y)");
+            $this->getSession()->executeScript("window.scrollTo($scrollHorizontal, $scrollVertical)");
         }
     }
 

--- a/src/Behat/FlexibleMink/Context/FlexibleContext.php
+++ b/src/Behat/FlexibleMink/Context/FlexibleContext.php
@@ -1075,7 +1075,7 @@ class FlexibleContext extends MinkContext
      *                                "top", "bottom", "left" and "right". e.g. "top", "top right", but not "top bottom"
      * @param bool   $useSmoothScroll Use the smooth scrolling behavior if the browser supports it.
      */
-    public function scrollWindowToBody(string $whereToScroll, bool $useSmoothScroll = false): void
+    public function scrollWindowToBody($whereToScroll, $useSmoothScroll = false)
     {
         // horizontal scroll
         $x = 'window.scrollX';

--- a/src/Behat/FlexibleMink/Context/FlexibleContext.php
+++ b/src/Behat/FlexibleMink/Context/FlexibleContext.php
@@ -1095,8 +1095,7 @@ class FlexibleContext extends MinkContext
 
         if ($supportsSmoothScroll) {
             $this->getSession()->executeScript("window.scrollTo({top: $y, left: $x, behavior: 'smooth'})");
-        }
-        else {
+        } else {
             $this->getSession()->executeScript("window.scrollTo($x, $y)");
         }
     }

--- a/src/Behat/FlexibleMink/Context/FlexibleContext.php
+++ b/src/Behat/FlexibleMink/Context/FlexibleContext.php
@@ -1091,7 +1091,14 @@ class FlexibleContext extends MinkContext
             $y = 'document.body.scrollHeight';
         }
 
-        $this->getSession()->executeScript("window.scrollTo({top: $y, left: $x, behavior: 'smooth'})");
+        $supportsSmoothScroll = $this->getSession()->evaluateScript("'scrollBehavior' in document.documentElement.style");
+
+        if ($supportsSmoothScroll) {
+            $this->getSession()->executeScript("window.scrollTo({top: $y, left: $x, behavior: 'smooth'})");
+        }
+        else {
+            $this->getSession()->executeScript("window.scrollTo($x, $y)");
+        }
     }
 
     /**

--- a/src/Behat/FlexibleMink/PseudoInterface/FlexibleContextInterface.php
+++ b/src/Behat/FlexibleMink/PseudoInterface/FlexibleContextInterface.php
@@ -417,9 +417,9 @@ trait FlexibleContextInterface
     /**
      * Scrolls the window to the top, bottom, left, right (or any valid combination thereof) of the page body.
      *
-     * @param string $where to scroll to. Can be any valid combination of "top", "bottom",
-     *                                                 "left" and "right". e.g. "top", "top right", but not "top bottom"
-     * @param bool $smooth scrolling flag.
+     * @param string $where  to scroll to. Can be any valid combination of "top", "bottom",
+     *                       "left" and "right". e.g. "top", "top right", but not "top bottom"
+     * @param bool   $smooth scrolling flag.
      */
     abstract public function scrollWindowToBody($where, $smooth = false);
 

--- a/src/Behat/FlexibleMink/PseudoInterface/FlexibleContextInterface.php
+++ b/src/Behat/FlexibleMink/PseudoInterface/FlexibleContextInterface.php
@@ -417,11 +417,11 @@ trait FlexibleContextInterface
     /**
      * Scrolls the window to the top, bottom, left, right (or any valid combination thereof) of the page body.
      *
-     * @param string $where  to scroll to. Can be any valid combination of "top", "bottom",
-     *                       "left" and "right". e.g. "top", "top right", but not "top bottom"
-     * @param bool   $smooth scrolling flag.
+     * @param string $whereToScroll   The direction to scroll the page. Can be any valid combination of "top", "bottom",
+     *                                "left" and "right". e.g. "top", "top right", but not "top bottom"
+     * @param bool   $useSmoothScroll Use the smooth scrolling behavior if the browser supports it.
      */
-    abstract public function scrollWindowToBody($where, $smooth = false);
+    abstract public function scrollWindowToBody(string $whereToScroll, bool $useSmoothScroll = false): void;
 
     /**
      * Finds the first visible element in the given set, prioritizing elements in the viewport but scrolling to one if

--- a/src/Behat/FlexibleMink/PseudoInterface/FlexibleContextInterface.php
+++ b/src/Behat/FlexibleMink/PseudoInterface/FlexibleContextInterface.php
@@ -417,12 +417,11 @@ trait FlexibleContextInterface
     /**
      * Scrolls the window to the top, bottom, left, right (or any valid combination thereof) of the page body.
      *
-     * @param  string                           $where to scroll to. Can be any valid combination of "top", "bottom",
+     * @param string $where to scroll to. Can be any valid combination of "top", "bottom",
      *                                                 "left" and "right". e.g. "top", "top right", but not "top bottom"
-     * @throws UnsupportedDriverActionException When operation not supported by the driver
-     * @throws DriverException                  When the operation cannot be done
+     * @param bool $smooth scrolling flag.
      */
-    abstract public function scrollWindowToBody($where);
+    abstract public function scrollWindowToBody($where, $smooth = false);
 
     /**
      * Finds the first visible element in the given set, prioritizing elements in the viewport but scrolling to one if

--- a/src/Behat/FlexibleMink/PseudoInterface/FlexibleContextInterface.php
+++ b/src/Behat/FlexibleMink/PseudoInterface/FlexibleContextInterface.php
@@ -421,7 +421,7 @@ trait FlexibleContextInterface
      *                                "left" and "right". e.g. "top", "top right", but not "top bottom"
      * @param bool   $useSmoothScroll Use the smooth scrolling behavior if the browser supports it.
      */
-    abstract public function scrollWindowToBody(string $whereToScroll, bool $useSmoothScroll = false): void;
+    abstract public function scrollWindowToBody($whereToScroll, $useSmoothScroll = false);
 
     /**
      * Finds the first visible element in the given set, prioritizing elements in the viewport but scrolling to one if


### PR DESCRIPTION
For https://github.com/medology/stdcheck.com/issues/8839

For the `scrollWindowToBody` method:
- Add parameter to use smooth scrolling when the browser supports it.
- Refactor the default value for `$x, $y` variables.
- Rename and document parameters.