### PR TITLE
Fix typo on scrollWindowToBody

### DIFF
--- a/features/FlexibleContext/assertElementIsDisplayed.feature
+++ b/features/FlexibleContext/assertElementIsDisplayed.feature
@@ -34,6 +34,12 @@ Feature: Assert an element is displayed or not displayed
      Then "the almost-last div" should be fully visible in the viewport
      Then "the last div" should be partially visible in the viewport
 
+  Scenario: Visibility works on smoothly scrolled pages
+    Given I am on "/big-page.html"
+    When I scroll to the bottom of the page smoothly
+    Then "the almost-last div" should be fully visible in the viewport
+    Then "the last div" should be partially visible in the viewport
+
   Scenario Outline: Throw a ExpectationException when visibility test fails
     When I assert that <Step Text to Assert>
     Then the assertion should throw a ExpectationException

--- a/features/FlexibleContext/assertElementIsDisplayed.feature
+++ b/features/FlexibleContext/assertElementIsDisplayed.feature
@@ -32,13 +32,13 @@ Feature: Assert an element is displayed or not displayed
     Given I am on "/big-page.html"
      When I scroll to the bottom of the page
      Then "the almost-last div" should be fully visible in the viewport
-     Then "the last div" should be partially visible in the viewport
+      And "the last div" should be partially visible in the viewport
 
   Scenario: Visibility works on smoothly scrolled pages
     Given I am on "/big-page.html"
-    When I scroll to the bottom of the page smoothly
-    Then "the almost-last div" should be fully visible in the viewport
-    Then "the last div" should be partially visible in the viewport
+     When I scroll to the bottom of the page smoothly
+     Then "the almost-last div" should be fully visible in the viewport
+      And "the last div" should be partially visible in the viewport
 
   Scenario Outline: Throw a ExpectationException when visibility test fails
     When I assert that <Step Text to Assert>

--- a/src/Behat/FlexibleMink/Context/FlexibleContext.php
+++ b/src/Behat/FlexibleMink/Context/FlexibleContext.php
@@ -1098,7 +1098,7 @@ class FlexibleContext extends MinkContext
         $supportsSmoothScroll = $this->getSession()->evaluateScript("'scrollBehavior' in document.documentElement.style");
 
         if ($useSmoothScroll && $supportsSmoothScroll) {
-            $this->getSession()->executeScript("window.scrollTo({top: $scrollVertical, left: $$scrollHorizontal, behavior: 'smooth'})");
+            $this->getSession()->executeScript("window.scrollTo({top: $scrollVertical, left: $scrollHorizontal, behavior: 'smooth'})");
         } else {
             $this->getSession()->executeScript("window.scrollTo($scrollHorizontal, $scrollVertical)");
         }


### PR DESCRIPTION
Follow up for PR https://github.com/medology/flexiblemink/issues/297

For the `scrollWindowToBody` method:
- Fix typo on `$$scrollHorizontal`, should be `$scrollHorizontal`