### PR TITLE
Fix all tests run on all nodes in CI.

### DIFF
--- a/src/Medology/Behat/Mink/TableContext.php
+++ b/src/Medology/Behat/Mink/TableContext.php
@@ -101,6 +101,7 @@ class TableContext implements Context
 
             if (!$splitCell) {
                 $colRow = $row;
+
                 break;
             }
         }

--- a/src/Medology/Behat/ParallelWorker/Extension.php
+++ b/src/Medology/Behat/ParallelWorker/Extension.php
@@ -26,7 +26,7 @@ class Extension implements ExtensionInterface
     public function load(ContainerBuilder $container, array $config)
     {
         $definition = new Definition(Controller::class, [new Reference(GherkinExtension::MANAGER_ID)]);
-        $definition->addTag(CliExtension::CONTROLLER_TAG);
+        $definition->addTag(CliExtension::CONTROLLER_TAG, ['priority' => 150]);
         $container->setDefinition(CliExtension::CONTROLLER_TAG . '.parallel_worker', $definition);
     }
 


### PR DESCRIPTION
## Problem:
All Behat tests are running on all nodes in CI, as if the parallel worker extension is not working correctly.

## Cause:
In the list of controllers that Behat uses, the parallel worker controller has moved from the 3rd to the last position to the very last position. The ExerciseController that used to be in the very last position is the one that actually executes the tests, so now that it is before the parallel worker controller, tests are being executed before the parallel worker controller has had a chance to filter them.

I investigated further and found that there is a "priority" option that can be passed when adding a tag to a service definition. This option was neither passed in Flexible Mink 1.x or 2.x, but for some reason, the default behavior when this is omitted has changed, causing the parallel worker controller to be the very last in the list.

## Fix:
The two controllers there were after the parallel controller in Flexible Mink 2.x have a priority of 0 & 100, so I set the priority of the parallel worker controller to 150. The next priority controller is at 200, so that leaves plenty of room to add controllers in-between if necessary.