### PR TITLE
Expose AsyncMink from FlexibleContext

### DIFF
--- a/src/Medology/Behat/HasWaitProxy.php
+++ b/src/Medology/Behat/HasWaitProxy.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Medology\Behat;
+
+use Exception;
+
+/**
+ * Provides basic functionality for Behat contexts that have a wait proxy.
+ *
+ * Host classes will need to:
+ *  - Define a specific protected wait property type.
+ *  - Add a typed property-read annotation to their docblock to facility strict type checking and auto-completion.
+ *  - Initialize the wait property in their constructor.
+ */
+trait HasWaitProxy
+{
+    protected $wait;
+
+    /**
+     * Dynamic accessor for the wait proxy.
+     *
+     * @param  string    $property the property to read.
+     * @throws Exception if the property does not exist on this class.
+     * @return mixed     the value of the property if it exists and is accessible.
+     */
+    public function __get($property)
+    {
+        if ($property === 'wait') {
+            return $this->wait;
+        }
+
+        throw new Exception('The property ' . __CLASS__ . "::$property does not exist");
+    }
+}

--- a/src/Medology/Behat/Mink/FlexibleContext.php
+++ b/src/Medology/Behat/Mink/FlexibleContext.php
@@ -15,6 +15,7 @@ use Behat\Mink\Exception\UnsupportedDriverActionException;
 use Behat\MinkExtension\Context\MinkContext;
 use Exception as GenericException;
 use InvalidArgumentException;
+use Medology\Behat\HasWaitProxy;
 use Medology\Behat\Mink\Models\Geometry\Rectangle;
 use Medology\Behat\StoreContext;
 use Medology\Behat\TypeCaster;
@@ -29,9 +30,12 @@ use ZipArchive;
 /**
  * Overwrites some MinkContext step definitions to make them more resilient to failures caused by browser/driver
  * discrepancies and unpredictable load times.
+ *
+ * @property-read AsyncMink $wait
  */
 class FlexibleContext extends MinkContext
 {
+    use HasWaitProxy;
     use TypeCaster;
     use UsesStoreContext;
 


### PR DESCRIPTION
__Problem:__
In projects leveraging FlexibleMink, there are often many different context classes that need access to FlexibleContext wrapped in AsyncMink. As a result, each host-context creates a new instance of AsyncMink. This is an unnecessary overhead, as there really only needs to be one wrapper since AsyncMink is just a spinner proxy and has no state of its own.

__Fix:__
I added the HasWaitProxy trait and mixed it into FlexibleContext. It allows read-only access to the wait property of the host class. This trait will be of use to other context classes that need to host their own spinner proxy, which is why I implemented it as a re-usable trait and not a modification to the FlexibleContext class itself.

﻿
