### PR TITLE
Load check for dynamic images

### DIFF
--- a/docker/lib/tty.sh
+++ b/docker/lib/tty.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+TTY='';
+if [ -t 0 ] ; then
+  TTY=t;
+fi

--- a/features/WebDownloadContext.feature
+++ b/features/WebDownloadContext.feature
@@ -7,7 +7,11 @@ Feature: Web Download Context
     Given I am on "/image-load-test.html"
 
   Scenario: Developer Can Test if an Image Link is Valid (Loads)
-    Then I should see "img/medology.png" image in "valid-image"
+    Then I should see "/img/medology.png" image in "valid-image"
 
   Scenario: Developer Can Test if an Image Link is Invalid (Broken)
     Then I should not see an image in "invalid-image"
+
+  Scenario: Developer Can Test if an Image loaded dynamicly
+    When I reload the page
+    Then I should see "/img/medology.png" image in "dynamic-image"

--- a/features/bootstrap/FeatureContext.php
+++ b/features/bootstrap/FeatureContext.php
@@ -120,7 +120,6 @@ JS
      * @param  string               $locator The id of the image tag
      * @throws ExpectationException If the <img> tag is not found
      * @throws ExpectationException If the image is not loaded
-     * @return true
      */
     public function assertImageLoaded($imgSrc, $locator)
     {
@@ -131,15 +130,9 @@ JS
             throw new ExpectationException("Expected an img tag with id '$locator'. Found none!", $session);
         }
 
-        if ($image->getAttribute('src') != $imgSrc) {
-            throw new ExpectationException("Expected src '$imgSrc'. Instead got '" . $image->getAttribute('src') . "'.", $session);
-        }
-
-        if (!$this->checkImageLoaded($image->getXpath())) {
+        if (!$this->checkImageLoaded($image->getXpath(), $imgSrc)) {
             throw new ExpectationException("Expected img '$locator' to load. Instead it did not!", $session);
         }
-
-        return true;
     }
 
     /**
@@ -150,7 +143,6 @@ JS
      * @param  string               $locator The id of the image tag
      * @throws ExpectationException If the <img> tag is not found
      * @throws ExpectationException If the image is loaded
-     * @return true
      */
     public function assertImageNotLoaded($locator)
     {
@@ -163,7 +155,5 @@ JS
         if ($this->checkImageLoaded($image->getXpath())) {
             throw new ExpectationException("Expected img '$locator' to not load. Instead it did load!", $this->getSession());
         }
-
-        return true;
     }
 }

--- a/src/Behat/FlexibleMink/Context/WebDownloadContext.php
+++ b/src/Behat/FlexibleMink/Context/WebDownloadContext.php
@@ -86,12 +86,12 @@ trait WebDownloadContext
     /**
      * {@inheritdoc}
      */
-    public function checkImageLoaded($xpath)
+    public function checkImageLoaded($xpath, $src = null)
     {
         $driver = $this->getSession()->getDriver();
         $xpath = str_replace('"', "'", $xpath);
 
-        $result = $this->waitFor(function () use ($driver, $xpath) {
+        $result = $this->waitFor(function () use ($driver, $xpath, $src) {
             if (!$driver->find($xpath)) {
                 throw new ElementNotFoundException($driver, 'img', 'xpath', $xpath);
             }
@@ -100,7 +100,9 @@ trait WebDownloadContext
 return {
     complete: document.evaluate("{$xpath}", document, null, XPathResult.FIRST_ORDERED_NODE_TYPE, null).singleNodeValue.complete,
     height: document.evaluate("{$xpath}", document, null, XPathResult.FIRST_ORDERED_NODE_TYPE, null).singleNodeValue.naturalHeight,
-    width: document.evaluate("{$xpath}", document, null, XPathResult.FIRST_ORDERED_NODE_TYPE, null).singleNodeValue.naturalWidth
+    width: document.evaluate("{$xpath}", document, null, XPathResult.FIRST_ORDERED_NODE_TYPE, null).singleNodeValue.naturalWidth,
+    src: document.evaluate("{$xpath}", document, null, XPathResult.FIRST_ORDERED_NODE_TYPE, null).singleNodeValue.currentSrc
+    .replace(location.protocol.concat("//").concat(window.location.hostname),"")
 }
 JS;
 
@@ -110,8 +112,15 @@ JS;
                 throw new Exception('Image did not finish loading.');
             }
 
+            if (!empty($src) && $imgProperties['src'] !== $src) {
+                throw new Exception(
+                    "The loaded image src is '{$imgProperties['src']}', but expected $src"
+                );
+            }
+
             return $imgProperties;
         });
+
 
         return $result['width'] !== 0 && $result['height'] !== 0;
     }

--- a/src/Behat/FlexibleMink/Context/WebDownloadContext.php
+++ b/src/Behat/FlexibleMink/Context/WebDownloadContext.php
@@ -121,7 +121,6 @@ JS;
             return $imgProperties;
         });
 
-
         return $result['width'] !== 0 && $result['height'] !== 0;
     }
 }

--- a/src/Behat/FlexibleMink/PseudoInterface/WebDownloadContextInterface.php
+++ b/src/Behat/FlexibleMink/PseudoInterface/WebDownloadContextInterface.php
@@ -41,8 +41,9 @@ trait WebDownloadContextInterface
      * This method checks if the image for an <img> tag actually loaded.
      *
      * @param  string                   $xpath The xpath of the <img> tag to check
+     * @param  null|string              $src   The image src must match if given
      * @throws ElementNotFoundException If an <img> tag was not found at {@paramref $xpath}
      * @return bool                     True if image loaded, false otherwise
      */
-    abstract public function checkImageLoaded($xpath);
+    abstract public function checkImageLoaded($xpath, $src = null);
 }

--- a/web/image-load-test.html
+++ b/web/image-load-test.html
@@ -9,6 +9,14 @@
       border: 2px solid #ccc;
     }
   </style>
+  <script>
+    window.onload = function() {
+      // Delay the load
+       setTimeout(function() {
+         document.getElementById('dynamic-image').src = 'img/medology.png';
+       }, 2000);
+    }
+  </script>
   <title>Table Test for Flexible Mink</title>
 </head>
 
@@ -17,6 +25,8 @@
   <img src="img/medology.png" id="valid-image" alt="Valid Image" />
   <h1>Invalid (Broken) Image</h1>
   <img src="img/doesnotexist.png" id="invalid-image" alt="Invalid Image" />
+  <h1>Dynamic Image</h1>
+  <img src="img/doesnotexist.png" id="dynamic-image" alt="Dynamic Image" />
 </body>
 
 </html>


### PR DESCRIPTION
### Problem description
We started to use dynamically loading images with no `src` or a placeholder URL instead of the actual image address. But in FlexibleMink we are checking the `src` attribute for comparison

### Solution
- Refactored the code so now it can test the actual loaded URL (`currentSrc`) instead of the attribute
- Added new test scenario for check the behavior
 

