### PR TITLE
Add spinner to actions such as click button.

### DIFF
--- a/src/Medology/Behat/Mink/FlexibleContext.php
+++ b/src/Medology/Behat/Mink/FlexibleContext.php
@@ -624,14 +624,14 @@ class FlexibleContext extends MinkContext
 
         /** @noinspection PhpUnhandledExceptionInspection */
         return Spinner::waitFor(function () use ($locator, $context) {
-          $context = $context ? $context : $this->getSession()->getPage();
-          $buttons = $context->findAll('named', ['button', $locator]);
+            $context = $context ? $context : $this->getSession()->getPage();
+            $buttons = $context->findAll('named', ['button', $locator]);
 
-          if (!($element = $this->scrollWindowToFirstVisibleElement($buttons))) {
-            throw new ExpectationException("No visible button found for '$locator'", $this->getSession());
-          }
+            if (!($element = $this->scrollWindowToFirstVisibleElement($buttons))) {
+                throw new ExpectationException("No visible button found for '$locator'", $this->getSession());
+            }
 
-          return $element;
+            return $element;
         });
     }
 
@@ -766,13 +766,13 @@ class FlexibleContext extends MinkContext
 
         /** @noinspection PhpUnhandledExceptionInspection */
         return Spinner::waitFor(function () use ($locator) {
-          $options = $this->getSession()->getPage()->findAll('named', ['field', $locator]);
+            $options = $this->getSession()->getPage()->findAll('named', ['field', $locator]);
 
-          if (!($element = $this->scrollWindowToFirstVisibleElement($options))) {
-              throw new ExpectationException("No visible option found for '$locator'", $this->getSession());
-          }
+            if (!($element = $this->scrollWindowToFirstVisibleElement($options))) {
+                throw new ExpectationException("No visible option found for '$locator'", $this->getSession());
+            }
 
-          return $element;
+            return $element;
         });
     }
 
@@ -818,19 +818,19 @@ class FlexibleContext extends MinkContext
      */
     public function scrollToField($fieldName, TraversableElement $context = null)
     {
-      /** @noinspection PhpUnhandledExceptionInspection */
-      return Spinner::waitFor(function () use ($fieldName, $context) {
-          $context = $context ?: $this->getSession()->getPage();
+        /** @noinspection PhpUnhandledExceptionInspection */
+        return Spinner::waitFor(function () use ($fieldName, $context) {
+            $context = $context ?: $this->getSession()->getPage();
 
-          /** @var NodeElement[] $fields */
-          $fields = ($context->findAll('named', ['field', $fieldName]) ?: $this->getInputsByLabel($fieldName, $context));
+            /** @var NodeElement[] $fields */
+            $fields = ($context->findAll('named', ['field', $fieldName]) ?: $this->getInputsByLabel($fieldName, $context));
 
-          if (!($element = $this->scrollWindowToFirstVisibleElement($fields))) {
-              throw new ExpectationException("No visible input found for '$fieldName'", $this->getSession());
-          }
+            if (!($element = $this->scrollWindowToFirstVisibleElement($fields))) {
+                throw new ExpectationException("No visible input found for '$fieldName'", $this->getSession());
+            }
 
-          return $element;
-      });
+            return $element;
+        });
     }
 
     /**

--- a/src/Medology/Behat/Mink/FlexibleContext.php
+++ b/src/Medology/Behat/Mink/FlexibleContext.php
@@ -2002,7 +2002,7 @@ JS
      *
      * @return NodeElement
      */
-    protected function findRadioButton($label)
+    public function findRadioButton($label)
     {
         $label = $this->storeContext->injectStoredValues($label);
         $this->fixStepArgument($label);

--- a/src/Medology/Behat/Mink/FlexibleContext.php
+++ b/src/Medology/Behat/Mink/FlexibleContext.php
@@ -1670,9 +1670,7 @@ class FlexibleContext extends MinkContext
             return -1;
         }
 
-        /* @noinspection PhpUndefinedMethodInspection */
         $aRect = $driver->getXpathBoundingClientRect($a->getXpath());
-        /* @noinspection PhpUndefinedMethodInspection */
         $bRect = $driver->getXpathBoundingClientRect($b->getXpath());
 
         if ($aRect['top'] == $bRect['top']) {

--- a/src/Medology/Behat/Mink/FlexibleContext.php
+++ b/src/Medology/Behat/Mink/FlexibleContext.php
@@ -1748,11 +1748,9 @@ class FlexibleContext extends MinkContext
      */
     public function assertNodeElementVisibleInViewport(NodeElement $element)
     {
-        Spinner::waitFor(function () use ($element) {
-            if (!$this->nodeIsVisibleInViewport($element)) {
-                throw new ExpectationException('The following element was expected to be visible in viewport, but was not: ' . $element->getHtml(), $this->getSession());
-            }
-        });
+        if (!$this->nodeIsVisibleInViewport($element)) {
+            throw new ExpectationException('The following element was expected to be visible in viewport, but was not: ' . $element->getHtml(), $this->getSession());
+        }
     }
 
     /**

--- a/src/Medology/Behat/Mink/FlexibleContext.php
+++ b/src/Medology/Behat/Mink/FlexibleContext.php
@@ -622,14 +622,17 @@ class FlexibleContext extends MinkContext
     {
         $locator = $this->fixStepArgument($locator);
 
-        $context = $context ? $context : $this->getSession()->getPage();
-        $buttons = $context->findAll('named', ['button', $locator]);
+        /** @noinspection PhpUnhandledExceptionInspection */
+        return Spinner::waitFor(function () use ($locator, $context) {
+          $context = $context ? $context : $this->getSession()->getPage();
+          $buttons = $context->findAll('named', ['button', $locator]);
 
-        if (!($element = $this->scrollWindowToFirstVisibleElement($buttons))) {
+          if (!($element = $this->scrollWindowToFirstVisibleElement($buttons))) {
             throw new ExpectationException("No visible button found for '$locator'", $this->getSession());
-        }
+          }
 
-        return $element;
+          return $element;
+        });
     }
 
     /**
@@ -677,13 +680,16 @@ class FlexibleContext extends MinkContext
      */
     public function scrollToLink($locator)
     {
-        $links = $this->getLinks($locator);
+        /** @noinspection PhpUnhandledExceptionInspection */
+        return Spinner::waitFor(function () use ($locator) {
+            $links = $this->getLinks($locator);
 
-        if (!($element = $this->scrollWindowToFirstVisibleElement($links))) {
-            throw new ExpectationException("No visible link found for '$locator'", $this->getSession());
-        }
+            if (!($element = $this->scrollWindowToFirstVisibleElement($links))) {
+                throw new ExpectationException("No visible link found for '$locator'", $this->getSession());
+            }
 
-        return $element;
+            return $element;
+        });
     }
 
     /**
@@ -757,13 +763,17 @@ class FlexibleContext extends MinkContext
     public function scrollToOption($locator)
     {
         $locator = $this->fixStepArgument($locator);
-        $options = $this->getSession()->getPage()->findAll('named', ['field', $locator]);
 
-        if (!($element = $this->scrollWindowToFirstVisibleElement($options))) {
-            throw new ExpectationException("No visible option found for '$locator'", $this->getSession());
-        }
+        /** @noinspection PhpUnhandledExceptionInspection */
+        return Spinner::waitFor(function () use ($locator) {
+          $options = $this->getSession()->getPage()->findAll('named', ['field', $locator]);
 
-        return $element;
+          if (!($element = $this->scrollWindowToFirstVisibleElement($options))) {
+              throw new ExpectationException("No visible option found for '$locator'", $this->getSession());
+          }
+
+          return $element;
+        });
     }
 
     /**
@@ -808,16 +818,19 @@ class FlexibleContext extends MinkContext
      */
     public function scrollToField($fieldName, TraversableElement $context = null)
     {
-        $context = $context ?: $this->getSession()->getPage();
+      /** @noinspection PhpUnhandledExceptionInspection */
+      return Spinner::waitFor(function () use ($fieldName, $context) {
+          $context = $context ?: $this->getSession()->getPage();
 
-        /** @var NodeElement[] $fields */
-        $fields = ($context->findAll('named', ['field', $fieldName]) ?: $this->getInputsByLabel($fieldName, $context));
+          /** @var NodeElement[] $fields */
+          $fields = ($context->findAll('named', ['field', $fieldName]) ?: $this->getInputsByLabel($fieldName, $context));
 
-        if (!($element = $this->scrollWindowToFirstVisibleElement($fields))) {
-            throw new ExpectationException("No visible input found for '$fieldName'", $this->getSession());
-        }
+          if (!($element = $this->scrollWindowToFirstVisibleElement($fields))) {
+              throw new ExpectationException("No visible input found for '$fieldName'", $this->getSession());
+          }
 
-        return $element;
+          return $element;
+      });
     }
 
     /**
@@ -1320,17 +1333,17 @@ class FlexibleContext extends MinkContext
      */
     public function pressButton($locator, TraversableElement $context = null)
     {
-        $button = $this->wait->scrollToButton($locator, $context);
-
         /* @noinspection PhpUnhandledExceptionInspection */
-        Spinner::waitFor(function () use ($button, $locator) {
+        Spinner::waitFor(function () use ($locator, $context) {
+            $button = $this->scrollToButton($locator, $context);
+
             if ($button->getAttribute('disabled') === 'disabled') {
                 throw new ExpectationException("Unable to press disabled button '$locator'.", $this->getSession());
             }
-        });
 
-        $this->assertNodeElementVisibleInViewport($button);
-        $button->press();
+            $this->assertNodeElementVisibleInViewport($button);
+            $button->press();
+        });
     }
 
     /**
@@ -1387,13 +1400,7 @@ class FlexibleContext extends MinkContext
         $select = $this->storeContext->injectStoredValues($select);
         $option = $this->storeContext->injectStoredValues($option);
 
-        /** @var NodeElement $field */
-        /** @noinspection PhpUnhandledExceptionInspection */
-        $field = Spinner::waitFor(function () use ($select, $context) {
-            return $this->assertVisibleOptionField($select, $context);
-        });
-
-        $field->selectOption($option);
+        $this->wait->assertVisibleOptionField($select, $context)->selectOption($option);
     }
 
     /**
@@ -1565,7 +1572,7 @@ class FlexibleContext extends MinkContext
      */
     public function ensureRadioButtonChecked($label)
     {
-        $this->findRadioButton($label)->click();
+        $this->wait->findRadioButton($label)->click();
     }
 
     /**


### PR DESCRIPTION
## Problem
Some of the "action" steps attempt to click buttons or interact with other form elements. When this occurs, the page might not have fully loaded yet, or the inputs might be temporarily disabled.

## Requirement
We want these actions to be resilient so that if it is not possible to perform the action at this exact time, the method waits and attempts a few times before giving up and allowing the exception to bubble up.

## Implementation
I have added a spinner to each of the FlexibleMink methods that are performing an action so that they can retry.