### PR TITLE
Check image

### DIFF
--- a/bin/init/wait_for_services.sh
+++ b/bin/init/wait_for_services.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -eu
+
 ROOT="$( cd "$( dirname "${BASH_SOURCE[0]}" )/../.." && pwd )"
 
 i=0
@@ -13,13 +15,17 @@ VERSION=edge
 
 . "$ROOT"/bin/lib/colors.sh
 . "$ROOT"/bin/lib/env.sh
-. "$ROOT"/bin/lib/rm.sh
 . "$ROOT"/bin/lib/tty.sh
 
 # Checks the status of the app, db and web services
 checkServices() {
+  # Disabled exit-on-error because we're using nc's failure to detect if services are up yet
+  set +e
+
   "$ROOT"/bin/nc -z web 80 &> /dev/null
   WEB_STATUS=$?
+
+  set -e
 }
 
 # Prints the status of service named $1 based on the status code of $2

--- a/bin/lib/tty.sh
+++ b/bin/lib/tty.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -eu
+
 TTY='';
 if [ -t 0 ] ; then
   TTY=t;

--- a/bin/linux-sed
+++ b/bin/linux-sed
@@ -5,7 +5,7 @@ set -eu
 ROOT="$( cd "$( dirname "${BASH_SOURCE[0]}" )/../" && pwd )"
 
 . "${ROOT}"/docker/lib/images.sh
-. "${ROOT}"/docker/lib/tty.sh
+. "${ROOT}"/bin/lib/tty.sh
 
 docker run \
   -i"${TTY}" \

--- a/features/WebDownloadContext.feature
+++ b/features/WebDownloadContext.feature
@@ -7,7 +7,15 @@ Feature: Web Download Context
     Given I am on "/image-load-test.html"
 
   Scenario: Developer Can Test if an Image Link is Valid (Loads)
-    Then I should see "img/medology.png" image in "valid-image"
+    Then I should see "/img/medology.png" image in "valid-image"
 
   Scenario: Developer Can Test if an Image Link is Invalid (Broken)
     Then I should not see an image in "invalid-image"
+
+  Scenario: Developer Can Test if an Image loaded dynamically
+    When I reload the page
+    Then I should see "/img/medology.png" image in "dynamic-image"
+
+  Scenario: Developer Can Test if an Image without src loaded dynamically
+    When I reload the page
+    Then I should see "/img/medology.png" image in "dynamic2-image"

--- a/features/bootstrap/FeatureContext.php
+++ b/features/bootstrap/FeatureContext.php
@@ -120,7 +120,6 @@ JS
      * @param  string               $locator The id of the image tag
      * @throws ExpectationException If the <img> tag is not found
      * @throws ExpectationException If the image is not loaded
-     * @return true
      */
     public function assertImageLoaded($imgSrc, $locator)
     {
@@ -131,15 +130,9 @@ JS
             throw new ExpectationException("Expected an img tag with id '$locator'. Found none!", $session);
         }
 
-        if ($image->getAttribute('src') != $imgSrc) {
-            throw new ExpectationException("Expected src '$imgSrc'. Instead got '" . $image->getAttribute('src') . "'.", $session);
-        }
-
-        if (!$this->checkImageLoaded($image->getXpath())) {
+        if (!$this->checkImageLoaded($image->getXpath(), $imgSrc)) {
             throw new ExpectationException("Expected img '$locator' to load. Instead it did not!", $session);
         }
-
-        return true;
     }
 
     /**
@@ -150,7 +143,6 @@ JS
      * @param  string               $locator The id of the image tag
      * @throws ExpectationException If the <img> tag is not found
      * @throws ExpectationException If the image is loaded
-     * @return true
      */
     public function assertImageNotLoaded($locator)
     {
@@ -163,7 +155,5 @@ JS
         if ($this->checkImageLoaded($image->getXpath())) {
             throw new ExpectationException("Expected img '$locator' to not load. Instead it did load!", $this->getSession());
         }
-
-        return true;
     }
 }

--- a/src/Behat/FlexibleMink/Context/WebDownloadContext.php
+++ b/src/Behat/FlexibleMink/Context/WebDownloadContext.php
@@ -86,12 +86,12 @@ trait WebDownloadContext
     /**
      * {@inheritdoc}
      */
-    public function checkImageLoaded($xpath)
+    public function checkImageLoaded($xpath, $src = null)
     {
         $driver = $this->getSession()->getDriver();
         $xpath = str_replace('"', "'", $xpath);
 
-        $result = $this->waitFor(function () use ($driver, $xpath) {
+        $result = $this->waitFor(function () use ($driver, $xpath, $src) {
             if (!$driver->find($xpath)) {
                 throw new ElementNotFoundException($driver, 'img', 'xpath', $xpath);
             }
@@ -100,7 +100,9 @@ trait WebDownloadContext
 return {
     complete: document.evaluate("{$xpath}", document, null, XPathResult.FIRST_ORDERED_NODE_TYPE, null).singleNodeValue.complete,
     height: document.evaluate("{$xpath}", document, null, XPathResult.FIRST_ORDERED_NODE_TYPE, null).singleNodeValue.naturalHeight,
-    width: document.evaluate("{$xpath}", document, null, XPathResult.FIRST_ORDERED_NODE_TYPE, null).singleNodeValue.naturalWidth
+    width: document.evaluate("{$xpath}", document, null, XPathResult.FIRST_ORDERED_NODE_TYPE, null).singleNodeValue.naturalWidth,
+    src: document.evaluate("{$xpath}", document, null, XPathResult.FIRST_ORDERED_NODE_TYPE, null).singleNodeValue.currentSrc
+    .replace(location.protocol.concat("//").concat(window.location.hostname),"")
 }
 JS;
 
@@ -108,6 +110,12 @@ JS;
 
             if (!$imgProperties['complete']) {
                 throw new Exception('Image did not finish loading.');
+            }
+
+            if (!empty($src) && $imgProperties['src'] !== $src) {
+                throw new Exception(
+                    "The loaded image src is '{$imgProperties['src']}', but expected $src"
+                );
             }
 
             return $imgProperties;

--- a/src/Behat/FlexibleMink/PseudoInterface/WebDownloadContextInterface.php
+++ b/src/Behat/FlexibleMink/PseudoInterface/WebDownloadContextInterface.php
@@ -41,8 +41,9 @@ trait WebDownloadContextInterface
      * This method checks if the image for an <img> tag actually loaded.
      *
      * @param  string                   $xpath The xpath of the <img> tag to check
+     * @param  null|string              $src   The image src must match if given
      * @throws ElementNotFoundException If an <img> tag was not found at {@paramref $xpath}
      * @return bool                     True if image loaded, false otherwise
      */
-    abstract public function checkImageLoaded($xpath);
+    abstract public function checkImageLoaded($xpath, $src = null);
 }

--- a/web/image-load-test.html
+++ b/web/image-load-test.html
@@ -9,6 +9,15 @@
       border: 2px solid #ccc;
     }
   </style>
+  <script>
+    window.onload = function() {
+      // Delay the load
+       setTimeout(function() {
+         document.getElementById('dynamic-image').src = 'img/medology.png';
+         document.getElementById('dynamic2-image').src = 'img/medology.png';
+       }, 2000);
+    }
+  </script>
   <title>Table Test for Flexible Mink</title>
 </head>
 
@@ -17,6 +26,10 @@
   <img src="img/medology.png" id="valid-image" alt="Valid Image" />
   <h1>Invalid (Broken) Image</h1>
   <img src="img/doesnotexist.png" id="invalid-image" alt="Invalid Image" />
+  <h1>Dynamic Image</h1>
+  <img src="img/placeholder.svg" id="dynamic-image" alt="Dynamic Image" />
+  <h1>Dynamic Image without src</h1>
+  <img id="dynamic2-image" alt="Dynamic Image without src" />
 </body>
 
 </html>

--- a/web/img/placeholder.svg
+++ b/web/img/placeholder.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1 1" width="1" height="1">
+  <path d="M0 4 L0 28 L32 28 L32 4 z M4 24 L10 10 L15 18 L18 14 L24 24z M25 7 A4 4 0 0 1 25 15 A4 4 0 0 1 25 7"></path>
+</svg>


### PR DESCRIPTION
For https://github.com/Medology/FlexibleMink/issues/321

### Problem description
We started to use dynamically loading images with no `src` or a placeholder URL instead of the actual image address. But in FlexibleMink we are checking the `src` attribute for comparison

### Solution
- Refactored the code so now it can test the actual loaded URL (`currentSrc`) instead of the attribute
- Added new test scenario for check the behavior
- Fixed some scripts used in CI build
 