### PR TITLE
Dynamic images assertion support for 2.0

### DIFF
--- a/bin/init/wait_for_services.sh
+++ b/bin/init/wait_for_services.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -eu
+
 ROOT="$( cd "$( dirname "${BASH_SOURCE[0]}" )/../.." && pwd )"
 
 i=0
@@ -13,13 +15,17 @@ VERSION=edge
 
 . "$ROOT"/bin/lib/colors.sh
 . "$ROOT"/bin/lib/env.sh
-. "$ROOT"/bin/lib/rm.sh
 . "$ROOT"/bin/lib/tty.sh
 
 # Checks the status of the app, db and web services
 checkServices() {
+  # Disabled exit-on-error because we're using nc's failure to detect if services are up yet
+  set +e
+
   "$ROOT"/bin/nc -z web 80 &> /dev/null
   WEB_STATUS=$?
+
+  set -e
 }
 
 # Prints the status of service named $1 based on the status code of $2

--- a/bin/lib/tty.sh
+++ b/bin/lib/tty.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -eu
+
 TTY='';
 if [ -t 0 ] ; then
   TTY=t;

--- a/bin/linux-sed
+++ b/bin/linux-sed
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+set -eu
+
+ROOT="$( cd "$( dirname "${BASH_SOURCE[0]}" )/../" && pwd )"
+
+. "${ROOT}"/docker/lib/images.sh
+. "${ROOT}"/bin/lib/tty.sh
+
+docker run \
+  -i"${TTY}" \
+  --env-file "$ROOT"/docker/.env \
+  --rm \
+ "${SED_IMAGE}" sed "$@"

--- a/docker/lib/php_image.sh
+++ b/docker/lib/php_image.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 
-if [ "$USE_PHP5" = "1" ]; then
+set -u
+
+if [ -z ${USE_PHP5:-} = "1" ]; then
     export RESOLVED_PHP_IMAGE=${PHP5_IMAGE}
 else
     export RESOLVED_PHP_IMAGE=${PHP7_IMAGE}

--- a/features/WebDownloadContext.feature
+++ b/features/WebDownloadContext.feature
@@ -18,4 +18,6 @@ Feature: Web Download Context
 
   Scenario: Developer Can Test if an Image without src loaded dynamically
     When I reload the page
+    Then I should see "/img/placeholder.svg" image in "dynamic2-image"
+    When I press "Load image"
     Then I should see "/img/medology.png" image in "dynamic2-image"

--- a/features/WebDownloadContext.feature
+++ b/features/WebDownloadContext.feature
@@ -7,7 +7,15 @@ Feature: Web Download Context
     Given I am on "/image-load-test.html"
 
   Scenario: Developer Can Test if an Image Link is Valid (Loads)
-    Then I should see "img/medology.png" image in "valid-image"
+    Then I should see "/img/medology.png" image in "valid-image"
 
   Scenario: Developer Can Test if an Image Link is Invalid (Broken)
     Then I should not see an image in "invalid-image"
+
+  Scenario: Developer Can Test if an Image loaded dynamically
+    When I reload the page
+    Then I should see "/img/medology.png" image in "dynamic-image"
+
+  Scenario: Developer Can Test if an Image without src loaded dynamically
+    When I reload the page
+    Then I should see "/img/medology.png" image in "dynamic2-image"

--- a/features/bootstrap/FeatureContext.php
+++ b/features/bootstrap/FeatureContext.php
@@ -130,8 +130,6 @@ JS
      *
      * @throws ExpectationException If the <img> tag is not found
      * @throws ExpectationException If the image is not loaded
-     *
-     * @return true
      */
     public function assertImageLoaded($imgSrc, $locator)
     {
@@ -142,15 +140,9 @@ JS
             throw new ExpectationException("Expected an img tag with id '$locator'. Found none!", $session);
         }
 
-        if ($image->getAttribute('src') != $imgSrc) {
-            throw new ExpectationException("Expected src '$imgSrc'. Instead got '" . $image->getAttribute('src') . "'.", $session);
-        }
-
-        if (!$this->webDownloadContext->checkImageLoaded($image->getXpath())) {
+        if (!$this->webDownloadContext->checkImageLoaded($image->getXpath(), $imgSrc)) {
             throw new ExpectationException("Expected img '$locator' to load. Instead it did not!", $session);
         }
-
-        return true;
     }
 
     /**
@@ -162,8 +154,6 @@ JS
      *
      * @throws ExpectationException If the <img> tag is not found
      * @throws ExpectationException If the image is loaded
-     *
-     * @return true
      */
     public function assertImageNotLoaded($locator)
     {
@@ -176,7 +166,5 @@ JS
         if ($this->webDownloadContext->checkImageLoaded($image->getXpath())) {
             throw new ExpectationException("Expected img '$locator' to not load. Instead it did load!", $this->flexibleContext->getSession());
         }
-
-        return true;
     }
 }

--- a/web/image-load-test.html
+++ b/web/image-load-test.html
@@ -14,8 +14,11 @@
       // Delay the load
        setTimeout(function() {
          document.getElementById('dynamic-image').src = 'img/medology.png';
-         document.getElementById('dynamic2-image').src = 'img/medology.png';
        }, 1000);
+    };
+
+    function load_img() {
+      document.getElementById('dynamic2-image').src = 'img/medology.png';
     }
   </script>
   <title>Table Test for Flexible Mink</title>
@@ -29,7 +32,8 @@
   <h1>Dynamic Image</h1>
   <img src="img/placeholder.svg" id="dynamic-image" alt="Dynamic Image" />
   <h1>Dynamic Image without src</h1>
-  <img id="dynamic2-image" alt="Dynamic Image without src" />
+  <img src="img/placeholder.svg" id="dynamic2-image" alt="Dynamic Image without src" />
+  <button onclick="load_img()" data-qa-id="Load image">Load image</button>
 </body>
 
 </html>

--- a/web/image-load-test.html
+++ b/web/image-load-test.html
@@ -9,6 +9,15 @@
       border: 2px solid #ccc;
     }
   </style>
+  <script>
+    window.onload = function() {
+      // Delay the load
+       setTimeout(function() {
+         document.getElementById('dynamic-image').src = 'img/medology.png';
+         document.getElementById('dynamic2-image').src = 'img/medology.png';
+       }, 1000);
+    }
+  </script>
   <title>Table Test for Flexible Mink</title>
 </head>
 
@@ -17,6 +26,10 @@
   <img src="img/medology.png" id="valid-image" alt="Valid Image" />
   <h1>Invalid (Broken) Image</h1>
   <img src="img/doesNotExist.png" id="invalid-image" alt="Invalid Image" />
+  <h1>Dynamic Image</h1>
+  <img src="img/placeholder.svg" id="dynamic-image" alt="Dynamic Image" />
+  <h1>Dynamic Image without src</h1>
+  <img id="dynamic2-image" alt="Dynamic Image without src" />
 </body>
 
 </html>

--- a/web/img/placeholder.svg
+++ b/web/img/placeholder.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1 1" width="1" height="1">
+  <path d="M0 4 L0 28 L32 28 L32 4 z M4 24 L10 10 L15 18 L18 14 L24 24z M25 7 A4 4 0 0 1 25 15 A4 4 0 0 1 25 7"></path>
+</svg>


### PR DESCRIPTION
For #321

### Problem description
We started to use dynamically loading images with no src or a placeholder URL instead of the actual image address. But in FlexibleMink we are checking the src attribute for comparison

### Solution
Refactored the code so now it can test the actual loaded URL (currentSrc) instead of the attribute
Added new test scenario for check the behavior
Fixed some scripts used in CI build