### PR TITLE
Move dev namespaces to autoload-dev

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,14 +27,13 @@
   },
   "autoload": {
     "psr-0": {
-      "": "src/",
-      "features": ""
-    },
-    "psr-4": {
-      "Tests\\": "tests"
+      "": "src/"
     }
   },
   "autoload-dev": {
+    "psr-0": {
+      "features": ""
+    },
     "psr-4": {
       "Tests\\": "tests/"
     }


### PR DESCRIPTION
## Problem
The "features" and "tests" namespaces were registered in the "autoload" section of compoer.json. This causes the host project to check these directories when looking for classes, which reduces performance. There is no need for a host project to use the test classes of a composer package.

## Fix
I removed the "tests" namespace from the "autoload" section (it was already duplicated in "autoload-dev"), and moved the "features" namespace to the "autoload-dev" section.