### PR TITLE
Patching false positive page address assertion (ver2)

### DIFF
--- a/features/FlexibleContext/assertPageAddress.feature
+++ b/features/FlexibleContext/assertPageAddress.feature
@@ -20,3 +20,7 @@ Feature: Assert Page Address Method
         | Param      | Value        | Error Message                                                  |
         | invalidKey | test         | Query did not contain a invalidKey parameter                   |
         | key        | invalidTest  | Expected query parameter key to be invalidTest, but found test |
+
+  Scenario: External URL address
+    When I go to "https://www.google.com"
+    Then I should be on "https://www.google.com/"

--- a/src/Medology/Behat/Mink/FlexibleContext.php
+++ b/src/Medology/Behat/Mink/FlexibleContext.php
@@ -79,18 +79,33 @@ class FlexibleContext extends MinkContext
 
         /* @noinspection PhpUnhandledExceptionInspection */
         Spinner::waitFor(function () use ($page) {
-            // is the page a path, or a full URL?
-            if (preg_match('!^https?://!', $page) == 0) {
-                // it's just a path. delegate to parents implementation
-                parent::assertPageAddress($page);
-            } else {
-                // it's a full URL, compare manually
-                $actual = $this->getSession()->getCurrentUrl();
-                if (!strpos($actual, $page) === 0) {
-                    throw new ExpectationException(sprintf('Current page is "%s", but "%s" expected.', $actual, $page), $this->getSession());
-                }
-            }
+            $this->assertPageAddressOnce($page);
         });
+    }
+
+    /**
+     * Logic for asserting a page address/URL. Call within a waitFor lambda function.
+     * Otherwise, call assertPageAddress, which calls this method in a waitFor for you.
+     *
+     * @param string $page the page to assert we're on
+     */
+    public function assertPageAddressOnce($page)
+    {
+        // is the page a path, or a full URL?
+        if (preg_match('!^https?://!', $page) == 0) {
+            // it's just a path. delegate to parents implementation
+            parent::assertPageAddress($page);
+        } else {
+            // it's a full URL, compare manually
+            $actual = rtrim($this->getSession()->getCurrentUrl(), '/');
+            $page = rtrim($page, '/');
+            if ($actual !== $page) {
+                throw new ExpectationException(
+                    sprintf('Current page is "%s", but "%s" expected.', $actual, $page),
+                    $this->getSession()
+                );
+            }
+        }
     }
 
     /**


### PR DESCRIPTION
For #325 

## Describe the bug
False positive assertion on behat tests where a link is clicked and the resulting page is verified to be a specified URL. I uncovered this when I changed a link's href, and then found a behat test asserting the proper webpage has opened was still passing with the old URL. 

## To Reproduce
Steps to reproduce the behavior:
1. Find any usage of `a new tab or window should open at...` in features directory that specifies a URL (paths seem to be working as intended). 
2. Swap The URL specified with something like `https://hello`, which obviously isn't a valid URL nor the href of the link being clicked.  
3. Run behat test.

## Expected behavior
Test should fail.

## Actual behavior
Test passes.

## Solution
`FlexibleContext::assertPageAddress`

```
if (!strpos($actual, $page) === 0) {
```
This was allowing every URL to pass. Another issue was using `strpos`. 
E.g., if `$actual` is `http://www.stdcheck.local/my-account.php#/stdcheck.com/main` 
and `$page` is `http://www.stdcheck.local/my-account.php`, 
this method would assert true despite the URLs being different.

I changed this conditional check to an equality (not strictly equal to `!==`)
```
if ($actual !== $page) {
```
And I trim any trailing slash off both `$page` and `$actual`

### Note:
Some behat tests and one call to `assertPageAddress` (in `WebContext`) will need to be modified in STDcheck. They will fail if these changes are merged and the updated version of FlexibleMink is specified in `composer.json` (version 1.x specifically). I will create a PR on STDcheck for these changes.