### PR TITLE
Add a wait for when asserting the number of rows in HTML tables

### DIFF
--- a/src/Behat/FlexibleMink/Context/TableContext.php
+++ b/src/Behat/FlexibleMink/Context/TableContext.php
@@ -296,19 +296,21 @@ trait TableContext
             throw new InvalidArgumentException('Number of rows must be an integer greater than 0.');
         }
 
-        $table = $this->getTableFromName($name);
+        return $this->waitFor(function () use ($name, $num, $fullTable) {
+            $table = $this->getTableFromName($name);
 
-        $rowCount = count($table['body']);
+            $rowCount = count($table['body']);
 
-        if ($fullTable) {
-            $rowCount += count($table['head']) + count($table['body']);
-        }
+            if ($fullTable) {
+                $rowCount += count($table['head']) + count($table['body']);
+            }
 
-        if ($rowCount != $num) {
-            throw new ExpectationException("Expected $num row(s) for table '$name'. Instead got $rowCount.", $this->getSession());
-        }
+            if ($rowCount != $num) {
+                throw new ExpectationException("Expected $num row(s) for table '$name'. Instead got $rowCount.", $this->getSession());
+            }
 
-        return true;
+            return true;
+        });
     }
 
     /**

--- a/src/Behat/FlexibleMink/Context/TableContext.php
+++ b/src/Behat/FlexibleMink/Context/TableContext.php
@@ -285,8 +285,6 @@ trait TableContext
     /**
      * {@inheritdoc}
      *
-     * @Given the table :name has 1 row
-     * @Given the table :name has :num rows
      * @Then the table :name should have 1 row
      * @Then the table :name should have :num rows
      */


### PR DESCRIPTION
For: https://github.com/Medology/stdcheck.com/issues/8707

This adds a spinner to the method that asserts the number rows in an HTML table.