### PR TITLE
Continuously refresh tables when assert amount of table rows

### DIFF
--- a/src/Behat/FlexibleMink/Context/TableContext.php
+++ b/src/Behat/FlexibleMink/Context/TableContext.php
@@ -295,7 +295,7 @@ trait TableContext
         }
 
         return $this->waitFor(function () use ($name, $num, $fullTable) {
-            $table = $this->getTableFromName($name);
+            $table = $this->getTableFromName($name, true);
 
             $rowCount = count($table['body']);
 


### PR DESCRIPTION
for: 8707

This is just a small change to keep from pulling the original table table from the store context when it is waiting for a change of amount of table rows.