### PR TITLE
Continuously refresh tables when assert amount of table rows

### DIFF
--- a/src/Medology/Behat/Mink/TableContext.php
+++ b/src/Medology/Behat/Mink/TableContext.php
@@ -102,7 +102,7 @@ class TableContext implements Context
             throw new InvalidArgumentException('Number of rows must be an integer greater than 0.');
         }
 
-        $table = $this->getTableFromName($name);
+        $table = $this->getTableFromName($name, true);
 
         $rowCount = count($table['body']);
 


### PR DESCRIPTION
for: 8707

This is just a small change to keep from pulling the original table table from the store context when it is waiting for a change of amount of table rows.