### PR TITLE
Fixed URL assertion logic

### DIFF
--- a/src/Behat/FlexibleMink/Context/FlexibleContext.php
+++ b/src/Behat/FlexibleMink/Context/FlexibleContext.php
@@ -87,9 +87,8 @@ class FlexibleContext extends MinkContext
             parent::assertPageAddress($page);
         } else {
             // it's a full URL, compare manually
-            $actual = rtrim($this->getSession()->getCurrentUrl(), '/');
-            $page = rtrim($page, '/');
-            if ($actual !== $page) {
+            $actual = $this->getSession()->getCurrentUrl();
+            if (strpos($actual, $page) !== 0) {
                 throw new ExpectationException(
                     sprintf('Current page is "%s", but "%s" expected.', $actual, $page),
                     $this->getSession()


### PR DESCRIPTION
For #325 
I created an issue by checking for strict equality when asserting a URL. We should only check if the actual page starts with the supplied URL.