### PR TITLE
Fix getListOfAllNodeElementParents includes stopAt node

### DIFF
--- a/src/Medology/Behat/Mink/FlexibleContext.php
+++ b/src/Medology/Behat/Mink/FlexibleContext.php
@@ -1769,7 +1769,10 @@ class FlexibleContext extends MinkContext
     public function assertNodeElementVisibleInViewport(NodeElement $element)
     {
         if (!$this->nodeIsVisibleInViewport($element)) {
-            throw new ExpectationException('The following element was expected to be visible in viewport, but was not: ' . $element->getHtml(), $this->getSession());
+            throw new ExpectationException(
+                'The following element was expected to be visible in viewport, but was not: ' . $element->getHtml(),
+                $this->getSession()
+            );
         }
     }
 
@@ -2042,7 +2045,7 @@ JS
     /**
      * Get list of of all NodeElement parents.
      *
-     * @param string $stopAt html tag to stop at
+     * @param string $stopAt html tag to stop at. This tag will NOT be included in the returned list.
      *
      * @return NodeElement[]
      */

--- a/web/button-disabled.html
+++ b/web/button-disabled.html
@@ -13,12 +13,14 @@
   </script>
 </head>
 <body>
+<div>
     <button type="button" id="disabled-button" disabled>Disabled Button</button>
     <button type="button" id="enabled-button">Enabled Button</button>
     <br>
     <br>
     <button type="button" onclick="enableDisabledButton()">Enable Disabled Button</button>
     <button type="button" onclick="disableEnabledButton()">Disable Enabled Button</button>
+</div>
 </body>
 </html>
 

--- a/web/select-option.html
+++ b/web/select-option.html
@@ -5,7 +5,8 @@
     <title>Assert Option in Select</title>
 </head>
 <body>
-<h1>Select</h1>
+<div>
+    <h1>Select</h1>
     <form>
         <label for="country">Country</label>
         <select id="country">
@@ -17,5 +18,8 @@
         <select id="state">
         </select>
     </form>
+
+    <button onclick="updateSelectWithDelay()">Update select with delay</button>
+</div>
 </body>
 </html>


### PR DESCRIPTION
For Medology/stdcheck.com#6717

This is a port of PR #257

# Problem:
The getListOfAllNodeElementParents method takes a stopAt argument, which was intended to prevent an ancestor matching the specified HTML tag from being included in the returned node elements. Instead, it was the last node element that was included in the returned list. The wording of the parameter name and the description did not make this clear. But the typical use case for this is to not include the body tag as it has some strange behavior regarding its viewport rectangle, overflow and whether or not elements outside of the rectangle are truly visible or not. Instead of fixing the body on pages that this problem manifests on, the developer decided to implement this approach and ignore the body instead.

# Implementation:
I ported the logic from PR #257 so that the method behaves this way in FlexibleMink 2.0 as well as 1.0.