### PR TITLE
Fix getListOfAllNodeElementParents includes stopAt node

### DIFF
--- a/src/Medology/Behat/Mink/FlexibleContext.php
+++ b/src/Medology/Behat/Mink/FlexibleContext.php
@@ -2050,8 +2050,8 @@ JS
     private function getAncestors(NodeElement $node, $stopAt)
     {
         $nodeElements = [];
-        while ($node->getParent() instanceof NodeElement) {
-            $nodeElements[] = ($node = $node->getParent());
+        while (($node = $node->getParent()) instanceof NodeElement) {
+            $nodeElements[] = $node;
             if (strcasecmp($node->getTagName(), $stopAt) === 0) {
                 break;
             }

--- a/src/Medology/Behat/Mink/FlexibleContext.php
+++ b/src/Medology/Behat/Mink/FlexibleContext.php
@@ -2049,15 +2049,15 @@ JS
      */
     private function getAncestors(NodeElement $node, $stopAt)
     {
-        $nodeElements = [];
+        $nodes = [];
         while (($node = $node->getParent()) instanceof NodeElement) {
             if (strcasecmp($node->getTagName(), $stopAt) === 0) {
                 break;
             }
 
-            $nodeElements[] = $node;
+            $nodes[] = $node;
         }
 
-        return $nodeElements;
+        return $nodes;
     }
 }

--- a/src/Medology/Behat/Mink/FlexibleContext.php
+++ b/src/Medology/Behat/Mink/FlexibleContext.php
@@ -2043,11 +2043,11 @@ JS
      * Returns all ancestors of the specified node element.
      *
      * @param NodeElement $node   the node element to fetch ancestors for.
-     * @param string      $stopAt html tag to stop at. This node will NOT be included in the returned list.
+     * @param string|null $stopAt html tag to stop at. This node will NOT be included in the returned list.
      *
      * @return NodeElement[]
      */
-    private function getAncestors(NodeElement $node, $stopAt)
+    private function getAncestors(NodeElement $node, $stopAt = null)
     {
         $nodes = [];
         while (($node = $node->getParent()) instanceof NodeElement) {

--- a/src/Medology/Behat/Mink/FlexibleContext.php
+++ b/src/Medology/Behat/Mink/FlexibleContext.php
@@ -1789,7 +1789,8 @@ class FlexibleContext extends MinkContext
 
         $parents = $this->getAncestors($element, 'body');
 
-        if (!$driver->isDisplayed($element->getXpath()) || count($parents) < 1) {
+        // if the element is displayed, or it is detached from the DOM, it is not visible
+        if (!$driver->isDisplayed($element->getXpath()) || !$element->getParent()) {
             return false;
         }
 

--- a/src/Medology/Behat/Mink/FlexibleContext.php
+++ b/src/Medology/Behat/Mink/FlexibleContext.php
@@ -2042,7 +2042,8 @@ JS
     /**
      * Returns all ancestors of the specified node element.
      *
-     * @param string $stopAt html tag to stop at
+     * @param NodeElement $node   the node element to fetch ancestors for.
+     * @param string      $stopAt html tag to stop at
      *
      * @return NodeElement[]
      */

--- a/src/Medology/Behat/Mink/FlexibleContext.php
+++ b/src/Medology/Behat/Mink/FlexibleContext.php
@@ -1742,7 +1742,7 @@ class FlexibleContext extends MinkContext
     {
         $driver = $this->assertSelenium2Driver('Checks if a node Element is fully visible in the viewport.');
         if (!$driver->isDisplayed($element->getXpath()) ||
-            count(($parents = $this->getListOfAllNodeElementParents($element, 'html'))) < 1
+            count(($parents = $this->getAncestors($element, 'html'))) < 1
         ) {
             return false;
         }
@@ -1787,7 +1787,7 @@ class FlexibleContext extends MinkContext
     {
         $driver = $this->assertSelenium2Driver('Checks if a node Element is visible in the viewport.');
 
-        $parents = $this->getListOfAllNodeElementParents($element, 'body');
+        $parents = $this->getAncestors($element, 'body');
 
         if (!$driver->isDisplayed($element->getXpath()) || count($parents) < 1) {
             return false;
@@ -2040,13 +2040,13 @@ JS
     }
 
     /**
-     * Get list of of all NodeElement parents.
+     * Returns all ancestors of the specified node element.
      *
      * @param string $stopAt html tag to stop at
      *
      * @return NodeElement[]
      */
-    private function getListOfAllNodeElementParents(NodeElement $nodeElement, $stopAt)
+    private function getAncestors(NodeElement $nodeElement, $stopAt)
     {
         $nodeElements = [];
         while ($nodeElement->getParent() instanceof NodeElement) {

--- a/src/Medology/Behat/Mink/FlexibleContext.php
+++ b/src/Medology/Behat/Mink/FlexibleContext.php
@@ -2046,12 +2046,12 @@ JS
      *
      * @return NodeElement[]
      */
-    private function getAncestors(NodeElement $nodeElement, $stopAt)
+    private function getAncestors(NodeElement $node, $stopAt)
     {
         $nodeElements = [];
-        while ($nodeElement->getParent() instanceof NodeElement) {
-            $nodeElements[] = ($nodeElement = $nodeElement->getParent());
-            if (strtolower($nodeElement->getTagName()) === strtolower($stopAt)) {
+        while ($node->getParent() instanceof NodeElement) {
+            $nodeElements[] = ($node = $node->getParent());
+            if (strtolower($node->getTagName()) === strtolower($stopAt)) {
                 break;
             }
         }

--- a/src/Medology/Behat/Mink/FlexibleContext.php
+++ b/src/Medology/Behat/Mink/FlexibleContext.php
@@ -2043,7 +2043,7 @@ JS
      * Returns all ancestors of the specified node element.
      *
      * @param NodeElement $node   the node element to fetch ancestors for.
-     * @param string      $stopAt html tag to stop at
+     * @param string      $stopAt html tag to stop at. This node will NOT be included in the returned list.
      *
      * @return NodeElement[]
      */
@@ -2051,10 +2051,11 @@ JS
     {
         $nodeElements = [];
         while (($node = $node->getParent()) instanceof NodeElement) {
-            $nodeElements[] = $node;
             if (strcasecmp($node->getTagName(), $stopAt) === 0) {
                 break;
             }
+
+            $nodeElements[] = $node;
         }
 
         return $nodeElements;

--- a/src/Medology/Behat/Mink/FlexibleContext.php
+++ b/src/Medology/Behat/Mink/FlexibleContext.php
@@ -2052,7 +2052,7 @@ JS
         $nodeElements = [];
         while ($node->getParent() instanceof NodeElement) {
             $nodeElements[] = ($node = $node->getParent());
-            if (strtolower($node->getTagName()) === strtolower($stopAt)) {
+            if (strcasecmp($node->getTagName(), $stopAt) === 0) {
                 break;
             }
         }

--- a/tests/Medology/Behat/Mink/FlexibleContext/FlexibleContextTest.php
+++ b/tests/Medology/Behat/Mink/FlexibleContext/FlexibleContextTest.php
@@ -6,12 +6,12 @@ use Behat\Mink\Element\DocumentElement;
 use Behat\Mink\Session;
 use Medology\Behat\Mink\FlexibleContext;
 use PHPUnit_Framework_MockObject_MockObject;
-use PHPUnit_Framework_TestCase;
+use Tests\TestCase;
 
 /**
  * Instantiates the FlexibleContext so it can be used in Unit Tests functions.
  */
-abstract class FlexibleContextTest extends PHPUnit_Framework_TestCase
+abstract class FlexibleContextTest extends TestCase
 {
     /** @var Session|PHPUnit_Framework_MockObject_MockObject */
     protected $sessionMock;

--- a/tests/Medology/Behat/Mink/FlexibleContext/GetAncestorsTest.php
+++ b/tests/Medology/Behat/Mink/FlexibleContext/GetAncestorsTest.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace Tests\Medology\Behat\Mink\FlexibleContext;
+
+use Behat\Mink\Element\NodeElement;
+use PHPUnit_Framework_MockObject_MockObject as MockObject;
+
+class GetAncestorsTest extends FlexibleContextTest
+{
+    private $body;
+    private $div;
+    private $list;
+    private $listItem;
+    private $button;
+
+    public function setUp() {
+        parent::setUp();
+
+        // Given I have an HTML body
+        $this->body = $this->mockNode('body');
+
+        // And the body has a div
+        $this->div = $this->mockNode('div', $this->body);
+
+        // And the div has an unordered list
+        $this->list = $this->mockNode('ul', $this->div);
+
+        // And the list has a list item
+        $this->listItem = $this->mockNode('li', $this->list);
+
+        // And the list item has a button
+        $this->button = $this->mockNode('button', $this->listItem);
+    }
+
+    public function testAllAncestorsAreReturned() {
+        // When I pass the button to allAncestors()
+        $ancestors = $this->invokeMethod($this->flexible_context, 'getAncestors', [$this->button, '']);
+
+        // Then all ancestors should be returned in the correct order
+        $this->assertCount(4, $ancestors, 'Number of returned ancestors should be 4');
+        $this->assertSame($this->listItem, $ancestors[0], "Button's first ancestor should be list item");
+        $this->assertSame($this->list, $ancestors[1], "Button's second ancestor should be list");
+        $this->assertSame($this->div, $ancestors[2], "Button's third ancestor should be div");
+        $this->assertSame($this->body, $ancestors[3], "Button's fourth ancestor should be body");
+    }
+
+    public function testStopAtIsNotReturned() {
+        // When I pass the button to allAncestors() and request that it stop at "body"
+        $ancestors = $this->invokeMethod($this->flexible_context, 'getAncestors', [$this->button, 'body']);
+
+        // Then all ancestors except body should be returned in the correct order
+        $this->assertCount(3, $ancestors, 'Number of returned ancestors should be 3');
+        $this->assertSame($this->listItem, $ancestors[0], "Button's first ancestor should be list item");
+        $this->assertSame($this->list, $ancestors[1], "Button's second ancestor should be list");
+        $this->assertSame($this->div, $ancestors[2], "Button's third ancestor should be div");
+    }
+
+    /**
+     * Creates a mocked NodeElement with an optional parent.
+     *
+     * @param  string           $tagName the type of node element to mock
+     * @param  NodeElement|null $parent  the optional parent for the node element
+     * @return MockObject|NodeElement
+     */
+    protected function mockNode($tagName, NodeElement $parent = null) {
+        $node = $this->createMock(NodeElement::class);
+        $node->method('getTagName')->willReturn($tagName);
+        $node->method('getParent')->willReturn($parent);
+
+        return $node;
+    }
+
+    public function tearDown() {
+        $this->body = null;
+        $this->div = null;
+        $this->list = null;
+        $this->listItem = null;
+        $this->button = null;
+
+        parent::tearDown();
+    }
+}

--- a/tests/Medology/Behat/Mink/FlexibleContext/GetAncestorsTest.php
+++ b/tests/Medology/Behat/Mink/FlexibleContext/GetAncestorsTest.php
@@ -13,7 +13,8 @@ class GetAncestorsTest extends FlexibleContextTest
     private $listItem;
     private $button;
 
-    public function setUp() {
+    public function setUp()
+    {
         parent::setUp();
 
         // Given I have an HTML body
@@ -32,7 +33,8 @@ class GetAncestorsTest extends FlexibleContextTest
         $this->button = $this->mockNode('button', $this->listItem);
     }
 
-    public function testAllAncestorsAreReturned() {
+    public function testAllAncestorsAreReturned()
+    {
         // When I pass the button to allAncestors()
         $ancestors = $this->invokeMethod($this->flexible_context, 'getAncestors', [$this->button]);
 
@@ -44,7 +46,8 @@ class GetAncestorsTest extends FlexibleContextTest
         $this->assertSame($this->body, $ancestors[3], "Button's fourth ancestor should be body");
     }
 
-    public function testStopAtIsNotReturned() {
+    public function testStopAtIsNotReturned()
+    {
         // When I pass the button to allAncestors() and request that it stop at "body"
         $ancestors = $this->invokeMethod($this->flexible_context, 'getAncestors', [$this->button, 'body']);
 
@@ -58,11 +61,12 @@ class GetAncestorsTest extends FlexibleContextTest
     /**
      * Creates a mocked NodeElement with an optional parent.
      *
-     * @param  string           $tagName the type of node element to mock
-     * @param  NodeElement|null $parent  the optional parent for the node element
+     * @param  string                 $tagName the type of node element to mock
+     * @param  NodeElement|null       $parent  the optional parent for the node element
      * @return MockObject|NodeElement
      */
-    protected function mockNode($tagName, NodeElement $parent = null) {
+    protected function mockNode($tagName, NodeElement $parent = null)
+    {
         $node = $this->createMock(NodeElement::class);
         $node->method('getTagName')->willReturn($tagName);
         $node->method('getParent')->willReturn($parent);
@@ -70,7 +74,8 @@ class GetAncestorsTest extends FlexibleContextTest
         return $node;
     }
 
-    public function tearDown() {
+    public function tearDown()
+    {
         $this->body = null;
         $this->div = null;
         $this->list = null;

--- a/tests/Medology/Behat/Mink/FlexibleContext/GetAncestorsTest.php
+++ b/tests/Medology/Behat/Mink/FlexibleContext/GetAncestorsTest.php
@@ -34,7 +34,7 @@ class GetAncestorsTest extends FlexibleContextTest
 
     public function testAllAncestorsAreReturned() {
         // When I pass the button to allAncestors()
-        $ancestors = $this->invokeMethod($this->flexible_context, 'getAncestors', [$this->button, '']);
+        $ancestors = $this->invokeMethod($this->flexible_context, 'getAncestors', [$this->button]);
 
         // Then all ancestors should be returned in the correct order
         $this->assertCount(4, $ancestors, 'Number of returned ancestors should be 4');

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -27,5 +27,4 @@ class TestCase extends PHPUnit_Framework_TestCase
 
         return $method->invokeArgs((is_string($object) ? null : $object), $parameters);
     }
-
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Tests;
+
+use PHPUnit_Framework_TestCase;
+use ReflectionClass;
+use ReflectionException;
+
+class TestCase extends PHPUnit_Framework_TestCase
+{
+    /**
+     * Call protected/private method of a class.
+     *
+     * @param object|string $object     Instantiated object that we will run method on
+     * @param string        $methodName Method name to call
+     * @param array         $parameters array of parameters to pass into method
+     *
+     * @throws ReflectionException if there is a problem invoking the method
+     *
+     * @return mixed method return
+     */
+    public function invokeMethod($object, $methodName, array $parameters = [])
+    {
+        $reflection = new ReflectionClass($object);
+        $method = $reflection->getMethod($methodName);
+        $method->setAccessible(true);
+
+        return $method->invokeArgs((is_string($object) ? null : $object), $parameters);
+    }
+
+}


### PR DESCRIPTION
For Medology/stdcheck.com#6717

This is a port of PR #257

## Problem:
The getListOfAllNodeElementParents takes a parameter called "stopAt". From the use cases in host projects, it seems that it was intended for the node that matches this parameter to not be included in the resulting node list. But the method was stopping at this node and included it, and only excluding all further parents. Flexible Mink 1.0 was already modified by PR 257 to modify the behavior so the stopAt node was not included in the returned list.

## Fix:
I implemented the exact same functionality as 257, but also took the opportunity to clean up the method and write unit tests for it.