### PR TITLE
Adding in pull approve config

### DIFF
--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -1,28 +1,8 @@
 version: 3
-extends: "https://api.github.com/repos/medology/Scripts/contents/Pull%20Approve/base.pullapprove.yml?ref=master"
-pullapprove_conditions:
-  - condition: "base.ref == 'master'"
-    unmet_status: failure
-    explanation: "PullApprove is not configured for this branch"
-  - condition: "'[DO NOT REVIEW]' not in title"
-    unmet_status: pending
-    explanation: "Not ready for review"
-  - condition: "state == 'open'"
-    unmet_status: failure
-    explanation: "PR must be open to be reviewed"
-  - condition: "'ci/circleci: build' in statuses.succeeded or 'Force Review' in labels"
-    unmet_status: pending
-    explanation: "ci/circleci: build must pass before requesting review"
-  - condition: "'ci/circleci: build-php5' in statuses.succeeded or 'Force Review' in labels"
-    unmet_status: pending
-    explanation: "ci/circleci: build-php5 must pass before requesting review"
-  - condition: "'ci/circleci: test' in statuses.succeeded or 'Force Review' in labels"
-    unmet_status: pending
-    explanation: "ci/circleci: test must pass before requesting review"
-  - condition: "'ci/circleci: test-php5' in statuses.succeeded or 'Force Review' in labels"
-    unmet_status: pending
-    explanation: "ci/circleci: test-php5 must pass before requesting review"
-  - condition: "'continuous-integration/styleci/pr' in statuses.succeeded or 'Force Review' in labels"
-    unmet_status: pending
-    explanation: "StyleCI must pass before requesting review"
+extends: "https://api.github.com/repos/medology/Scripts/contents/config/base.pullapprove.yml?ref=master"
+groups:
+  min_global_approvals:
+    reviewers:
+      teams:
+        - Back-end
 


### PR DESCRIPTION
Adding in config extending the scripts repos base config. This configuration has been simplified to fix several issues we are having with pull aprove 


Note for QA: Pull requests are solely updating the config file for how we assign reviewers. Nothing in this PR will be testable.