### PR TITLE
Fix stale data returned from getTableFromName

### DIFF
--- a/src/Medology/Behat/Mink/TableContext.php
+++ b/src/Medology/Behat/Mink/TableContext.php
@@ -20,22 +20,14 @@ class TableContext implements Context
     use UsesStoreContext;
 
     /**
-     * This method will retrieve a table by its name. If the table is stored in the key store, that will be used,
-     * otherwise a fresh parse will be done against the table's HTML. Setting $forceFresh to true will ignore the key
-     * store and build the table from HTML.
+     * This method will retrieve a table by its name.
      *
-     * @param string $name       The name of the table to be used in an xpath query
-     * @param bool   $forceFresh Setting to true will rebuild the table from HTML and not use the store
+     * @param string $name The name of the table to be used in an xpath query
      *
-     * @return array An array containing parsed rows and cells as returned form $this->buildTableFromHtml
+     * @return array An array containing parsed rows and cells as returned from $this->buildTableFromHtml
      */
-    public function getTableFromName($name, $forceFresh = false)
+    public function getTableFromName($name)
     {
-        // retrieve table from the store if it exists there
-        if ($this->storeContext->keyExists($name) && !$forceFresh) {
-            return $this->storeContext->get($name);
-        }
-
         // find the table node and parse it's contents
         $table = $this->findNamedTable($name);
         $tableData = $this->buildTableFromHtml($table);
@@ -43,20 +35,6 @@ class TableContext implements Context
         $this->storeContext->set($name, $tableData);
 
         return $tableData;
-    }
-
-    /**
-     * Re-parses the table give by $name ensuring the key store is up to date.
-     *
-     * @Then   the table :name is updated
-     *
-     * @param string $name The name of the table
-     *
-     * @return array An array of the parsed table as returned by $this->buildTableFromHtml
-     */
-    public function refreshTable($name)
-    {
-        return $this->getTableFromName($name, true);
     }
 
     /**
@@ -106,7 +84,7 @@ class TableContext implements Context
             throw new InvalidArgumentException('Number of rows must be an integer greater than 0.');
         }
 
-        $table = $this->getTableFromName($name, true);
+        $table = $this->getTableFromName($name);
 
         $rowCount = count($table['body']);
 
@@ -311,7 +289,7 @@ class TableContext implements Context
     {
         $expectedRow = $tableNode->getRowsHash();
 
-        $actualTable = $this->getTableFromName($name, true);
+        $actualTable = $this->getTableFromName($name);
         $colHeaders = $actualTable['colHeaders'];
 
         array_walk($actualTable['body'], function (&$row) use ($colHeaders) {


### PR DESCRIPTION
For #349
Related to Medology/stdcheck.com#6717

## Problem:
In FlexibleMink 1.0, the getTableFromName() method would return a cached version of the table structure if it was available and the forceFresh parameter was not true. This worked fine for 1.0, but since 2.0 is intended to be used with the automatic spinning of the BehatRetryExtension, it was preventing the retry from ever passing. This was due to the first call returning the fresh table data that did not pass the assertion, and subsequent calls would receive the stale data even if the real table on the page had updated and should pass the assertion.

## Fix:
I removed the caching entirely. It is not appropriate for a generic table checking method, especially in an async environment such as Selenium. If the users of FlexibleMink want caching (say, because they are using the sync MinkDriver instead of the async SeleniumDriver), then they can implement caching around FlexibleMink.