### PR TITLE
Fix bug with the type caster casting ints that are too big

### DIFF
--- a/src/Behat/FlexibleMink/Context/TypeCaster.php
+++ b/src/Behat/FlexibleMink/Context/TypeCaster.php
@@ -12,7 +12,7 @@ trait TypeCaster
      *
      * @Transform /^(0|[1-9]\d*)$/
      * @param  string $string the string to cast.
-     * @return int    The resulting int.
+     * @return string|int    The resulting int.
      */
     public function castStringToInt($string)
     {

--- a/src/Behat/FlexibleMink/Context/TypeCaster.php
+++ b/src/Behat/FlexibleMink/Context/TypeCaster.php
@@ -16,7 +16,9 @@ trait TypeCaster
      */
     public function castStringToInt($string)
     {
-        return $string <= PHP_INT_MAX ? intval($string) : $string;
+        $intval = intval($string);
+
+        return strval($intval) === $string ? $intval : $string;
     }
 
     /**

--- a/src/Behat/FlexibleMink/Context/TypeCaster.php
+++ b/src/Behat/FlexibleMink/Context/TypeCaster.php
@@ -11,8 +11,8 @@ trait TypeCaster
      * Casts a step argument from a string to an int.
      *
      * @Transform /^(0|[1-9]\d*)$/
-     * @param  string $string the string to cast.
-     * @return string|int    The resulting int.
+     * @param  string     $string the string to cast.
+     * @return string|int The resulting int.
      */
     public function castStringToInt($string)
     {

--- a/src/Behat/FlexibleMink/Context/TypeCaster.php
+++ b/src/Behat/FlexibleMink/Context/TypeCaster.php
@@ -10,9 +10,14 @@ trait TypeCaster
     /**
      * Casts a step argument from a string to an int.
      *
-     * @Transform /^(0|[1-9]\d*)$/
-     * @param  string     $string the string to cast.
-     * @return string|int The resulting int.
+     * Will cast the string to an int if the string is int like and within the max int range of the system.
+     * Otherwise, the original string will be returned unmodified.
+     *
+     * @Transform /^((\-\d+)|\d+)$/
+     *
+     * @param string $string the string to cast
+     *
+     * @return int|string the string cast to an int, or the original string if it is outside the max int range of the system
      */
     public function castStringToInt($string)
     {

--- a/src/Behat/FlexibleMink/Context/TypeCaster.php
+++ b/src/Behat/FlexibleMink/Context/TypeCaster.php
@@ -13,7 +13,7 @@ trait TypeCaster
      * Will cast the string to an int if the string is int like and within the max int range of the system.
      * Otherwise, the original string will be returned unmodified.
      *
-     * @Transform /^((\-\d+)|\d+)$/
+     * @Transform /^(0|-?[1-9]\d*)$/
      *
      * @param string $string the string to cast
      *

--- a/src/Behat/FlexibleMink/Context/TypeCaster.php
+++ b/src/Behat/FlexibleMink/Context/TypeCaster.php
@@ -16,7 +16,7 @@ trait TypeCaster
      */
     public function castStringToInt($string)
     {
-        return intval($string);
+        return $string <= PHP_INT_MAX ? intval($string) : $string;
     }
 
     /**
@@ -28,6 +28,7 @@ trait TypeCaster
      */
     public function castStringToFloat($string)
     {
+        /** @todo Add PHP_FLOAT_MAX check when we move all our projects to at least php 7.2 */
         return floatval($string);
     }
 

--- a/tests/Behat/FlexibleMink/Context/TypeCaster/CastStringToIntTest.php
+++ b/tests/Behat/FlexibleMink/Context/TypeCaster/CastStringToIntTest.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Tests\Behat\FlexibleMink\Context\TypeCaster;
+
+use Behat\FlexibleMink\Context\TypeCaster;
+use PHPUnit\Framework\TestCase;
+use PHPUnit_Framework_MockObject_MockObject;
+
+/**
+ * Tests numbers are casted properly.
+ *
+ * @covers \Behat\FlexibleMink\Context\TypeCaster::castStringToInt()
+ */
+class CastStringToIntTest extends TestCase
+{
+    /** @var PHPUnit_Framework_MockObject_MockObject|TypeCaster  */
+    private $typeCasterTraitMock;
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function setUp()
+    {
+        parent::setUp();
+        $this->typeCasterTraitMock = $this->getMockForTrait(TypeCaster::class);
+    }
+
+    /**
+     * Test numbers are converted properly.
+     *
+     * @param $input    string The input to the conversion method.
+     * @param $expected mixed  The out put of the conversion method.
+     *
+     * @dataProvider conversionExamples
+     */
+    public function testNumbersBiggerPhpMaxIntAreCastedToStrings($input, $expected)
+    {
+        self::assertSame($expected, $this->typeCasterTraitMock->castStringToInt($input));
+    }
+
+    /**
+     * Conversion examples of expected outputs based on the input.
+     */
+    public function conversionExamples()
+    {
+        return [
+            'numeric string values more than PHP_INT_MAX are not converted to integers' =>
+                ['9223372036854775808', '9223372036854775808'],
+            'numeric string values equal to PHP_INT_MAX are converted to integers' =>
+                ['9223372036854775807', 9223372036854775807],
+            'numeric string values less than PHP_INT_MAX are converted to integers' =>
+                ['9223372036854775806', 9223372036854775806],
+            'zero string values is converted to a integer' =>
+                ['0', 0],
+            'low number string value is converted to a integer' =>
+                ['1', 1],
+            'negative number string value is converted to a integer' =>
+                ['-9999', -9999],
+            'negative numeric string values less than negative PHP_INT_MAX are not converted to integers' =>
+                ['-9223372036854775809', '-9223372036854775809'],
+        ];
+    }
+}

--- a/tests/Behat/FlexibleMink/Context/TypeCaster/CastStringToIntTest.php
+++ b/tests/Behat/FlexibleMink/Context/TypeCaster/CastStringToIntTest.php
@@ -13,11 +13,11 @@ use PHPUnit_Framework_MockObject_MockObject;
  */
 class CastStringToIntTest extends TestCase
 {
-    /** @var PHPUnit_Framework_MockObject_MockObject|TypeCaster  */
+    /** @var PHPUnit_Framework_MockObject_MockObject|TypeCaster */
     private $typeCasterTraitMock;
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     protected function setUp()
     {
@@ -44,20 +44,13 @@ class CastStringToIntTest extends TestCase
     public function conversionExamples()
     {
         return [
-            'numeric string values more than PHP_INT_MAX are not converted to integers' =>
-                ['9223372036854775808', '9223372036854775808'],
-            'numeric string values equal to PHP_INT_MAX are converted to integers' =>
-                ['9223372036854775807', 9223372036854775807],
-            'numeric string values less than PHP_INT_MAX are converted to integers' =>
-                ['9223372036854775806', 9223372036854775806],
-            'zero string values is converted to a integer' =>
-                ['0', 0],
-            'low number string value is converted to a integer' =>
-                ['1', 1],
-            'negative number string value is converted to a integer' =>
-                ['-9999', -9999],
-            'negative numeric string values less than negative PHP_INT_MAX are not converted to integers' =>
-                ['-9223372036854775809', '-9223372036854775809'],
+            'numeric string values more than PHP_INT_MAX are not converted to integers'                   => ['9223372036854775808', '9223372036854775808'],
+            'numeric string values equal to PHP_INT_MAX are converted to integers'                        => ['9223372036854775807', 9223372036854775807],
+            'numeric string values less than PHP_INT_MAX are converted to integers'                       => ['9223372036854775806', 9223372036854775806],
+            'zero string values is converted to a integer'                                                => ['0', 0],
+            'low number string value is converted to a integer'                                           => ['1', 1],
+            'negative number string value is converted to a integer'                                      => ['-9999', -9999],
+            'negative numeric string values less than negative PHP_INT_MAX are not converted to integers' => ['-9223372036854775809', '-9223372036854775809'],
         ];
     }
 }


### PR DESCRIPTION
**Method:**
Using a number as a string that is more than PHP_MAX_INT

**Expected Behavior:**
The number should have the same string value

**Actual Result:**
The number does not have the same string value if the number is more than PHP_MAX_INT

**Cause:**
The type caster's regex matches all numbers based on a regex.

**Solution:**
Add logic to the type caster to check if PHP_MAX_IN is less than the string value and return the string value if the int  would be bigger than PHP_MAX_INT

