### PR TITLE
Create formatter for phone numbers.

### DIFF
--- a/.idea/php.xml
+++ b/.idea/php.xml
@@ -49,7 +49,7 @@
   </component>
   <component name="PhpUnit">
     <phpunit_settings>
-      <PhpUnitSettings load_method="CUSTOM_LOADER" custom_loader_path="$PROJECT_DIR$/vendor/autoload.php" />
+      <PhpUnitSettings custom_loader_path="$PROJECT_DIR$/vendor/autoload.php" />
     </phpunit_settings>
   </component>
 </project>

--- a/.pullapprove
+++ b/.pullapprove
@@ -1,4 +1,0 @@
-version: 3
-extends: "https://api.github.com/repos/medology/Scripts/contents/Pull%20Approve/base.pullapprove.yml?ref=master"
-pullapprove_conditions:
-  - "base.ref == 'master'"

--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -1,7 +1,7 @@
 version: 3
-extends: "https://api.github.com/repos/medology/Scripts/contents/Pull%20Approve/base.pullapprove.yml?ref=master"
+extends: "https://api.github.com/repos/medology/Scripts/contents/Pull%20Approve/arepa.pullapprove.yml?ref=master"
 pullapprove_conditions:
-  - condition: "base.ref == '1.0'"
+  - condition: "base.ref == 'master'"
     unmet_status: failure
     explanation: "PullApprove is not configured for this branch"
   - condition: "'[DO NOT REVIEW]' not in title"
@@ -22,7 +22,3 @@ pullapprove_conditions:
   - condition: "'ci/circleci: test-php5' in statuses.succeeded or 'Force Review' in labels"
     unmet_status: pending
     explanation: "ci/circleci: test-php5 must pass before requesting review"
-  - condition: "'continuous-integration/styleci/pr' in statuses.succeeded or 'Force Review' in labels"
-    unmet_status: pending
-    explanation: "StyleCI must pass before requesting review"
-

--- a/src/Behat/FlexibleMink/Context/StoreContext.php
+++ b/src/Behat/FlexibleMink/Context/StoreContext.php
@@ -26,17 +26,14 @@ trait StoreContext
 
     protected static $dateFormat = DateTime::ISO8601;
 
-    protected static $FORMAT_MYSQL_DATE = 'a MySQL date';
-    protected static $FORMAT_MYSQL_DATE_AND_TIME = 'a MySQL date and time';
-    protected static $FORMAT_US_DATE = 'a US date';
-    protected static $FORMAT_US_DATE_AND_TIME = 'a US date and time';
-    protected static $FORMAT_US_DATE_AND_12HR_TIME = 'a US date and 12hr time';
     protected static $format_map = [
-        'a MySQL date'            => 'Y-m-d',
-        'a MySQL date and time'   => 'Y-m-d H:i:s',
-        'a US date'               => 'm/d/Y',
-        'a US date and time'      => 'm/d/Y H:i:s',
-        'a US date and 12hr time' => 'm/d/Y \a\t g:i A',
+        'a MySQL date'               => 'Y-m-d',
+        'a MySQL date and time'      => 'Y-m-d H:i:s',
+        'a US date'                  => 'm/d/Y',
+        'a US date and time'         => 'm/d/Y H:i:s',
+        'a US date and 12hr time'    => 'm/d/Y \a\t g:i A',
+        'a US phone number'          => ['/(\d{3})(\d{3})(\d{4})/', '($1) $2-$3'],
+        'a ###-###-### phone number' => ['/(\d{3})(\d{3})(\d{4})/', '$1-$2-$3'],
     ];
 
     /**
@@ -289,7 +286,7 @@ trait StoreContext
      *
      * @param  mixed  $property       the property to get from the object
      * @param  object $thing          the object to get the value from
-     * @param  string $propertyFormat the pattern for formatting the value.
+     * @param  mixed  $propertyFormat the pattern for formatting the value.
      * @return mixed  the prepared value
      */
     protected function getValueForInjection($property, $thing, $propertyFormat = null)
@@ -302,6 +299,8 @@ trait StoreContext
 
         if ($value instanceof DateTime) {
             $value = $this->formatDateTime($value, $thing, $propertyFormat);
+        } else if (is_string($value) && is_array($propertyFormat)) {
+            $value = preg_replace($propertyFormat[0], $propertyFormat[1], $value);
         }
 
         return $value;
@@ -314,7 +313,7 @@ trait StoreContext
      *
      * @param  string                   $propertyFormat the name of the property format to process.
      * @throws InvalidArgumentException if the property format is not supported.
-     * @return string                   the programmatic format.
+     * @return mixed                    the programmatic format.
      */
     protected function processPropertyFormat($propertyFormat)
     {

--- a/src/Behat/FlexibleMink/Context/StoreContext.php
+++ b/src/Behat/FlexibleMink/Context/StoreContext.php
@@ -284,9 +284,10 @@ trait StoreContext
     /**
      * Fetches a value from an object and ensures it is prepared for injection into a string.
      *
-     * @param  mixed  $property       the property to get from the object
-     * @param  object $thing          the object to get the value from
-     * @param  mixed  $propertyFormat the pattern for formatting the value.
+     * @param  mixed       $property       the property to get from the object
+     * @param  object      $thing          the object to get the value from
+     * @param  mixed|null  $propertyFormat the pattern for formatting the value.
+     *
      * @return mixed  the prepared value
      */
     protected function getValueForInjection($property, $thing, $propertyFormat = null)

--- a/tests/Behat/FlexibleMink/Context/StoreContextTest.php
+++ b/tests/Behat/FlexibleMink/Context/StoreContextTest.php
@@ -431,18 +431,6 @@ class StoreContextTest extends PHPUnit_Framework_TestCase
             '10/28/2028 at 3:30 PM',
             $this->injectStoredValues('(the date_prop of the testObj formatted as a US date and 12hr time)')
         );
-
-        // Phone is formatted as US phone specified format
-        $this->assertEquals(
-            '(441) 403-1737',
-            $this->injectStoredValues('(the phone_prop of the testObj formatted as a US phone number)')
-        );
-
-        // Phone is formatted as ###-###-#### specified format
-        $this->assertEquals(
-            '441-403-1737',
-            $this->injectStoredValues('(the phone_prop of the testObj formatted as ###-###-#### phone number)')
-        );
     }
 
     /**
@@ -507,6 +495,38 @@ class StoreContextTest extends PHPUnit_Framework_TestCase
          ***********************/
         $this->assertEquals(['1 University', null], $this->parseKey('1 University'));
         $this->assertEquals(['2 University', null], $this->parseKey('2 University'));
+    }
+
+    public function phoneNumberFormatDataProvider()
+    {
+        return [
+            'Phone is formatted with default format when no format is specified' => [
+                '(the phone_prop of the testObj)',
+                '4414031737',
+            ],
+            'Phone is formatted with specified US format' => [
+                '(the phone_prop of the testObj formatted as a US phone number)',
+                '(441) 403-1737',
+            ],
+            'Phone is formatted as specified ###-###-#### format' => [
+                '(the phone_prop of the testObj formatted as a ###-###-### phone number)',
+                '(441) 403-1737',
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider phoneNumberFormatDataProvider
+     *
+     * @param $input
+     * @param $output
+     */
+    public function testPhoneNumberFormatting($input, $output)
+    {
+        $testObj = $this->getMockObject();
+        $name = 'testObj';
+        $this->put($testObj, $name);
+        $this->assertEquals($output, $this->injectStoredValues($input));
     }
 
     /**

--- a/tests/Behat/FlexibleMink/Context/StoreContextTest.php
+++ b/tests/Behat/FlexibleMink/Context/StoreContextTest.php
@@ -510,7 +510,7 @@ class StoreContextTest extends PHPUnit_Framework_TestCase
             ],
             'Phone is formatted as specified ###-###-#### format' => [
                 '(the phone_prop of the testObj formatted as a ###-###-### phone number)',
-                '(441) 403-1737',
+                '441-403-1737',
             ],
         ];
     }

--- a/tests/Behat/FlexibleMink/Context/StoreContextTest.php
+++ b/tests/Behat/FlexibleMink/Context/StoreContextTest.php
@@ -30,6 +30,7 @@ class StoreContextTest extends PHPUnit_Framework_TestCase
             'test_property_2' => 'test_value_2',
             'test_property_3' => 'test_value_3',
             'date_prop'       => new DateTime('2028-10-28 15:30:10'),
+            'phone_prop'      => '4414031737',
         ];
 
         return $obj;
@@ -429,6 +430,18 @@ class StoreContextTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(
             '10/28/2028 at 3:30 PM',
             $this->injectStoredValues('(the date_prop of the testObj formatted as a US date and 12hr time)')
+        );
+
+        // Phone is formatted as US phone specified format
+        $this->assertEquals(
+            '(441) 403-1737',
+            $this->injectStoredValues('(the phone_prop of the testObj formatted as a US phone number)')
+        );
+
+        // Phone is formatted as ###-###-#### specified format
+        $this->assertEquals(
+            '441-403-1737',
+            $this->injectStoredValues('(the phone_prop of the testObj formatted as ###-###-#### phone number)')
         );
     }
 

--- a/tests/Behat/FlexibleMink/Context/StoreContextTest.php
+++ b/tests/Behat/FlexibleMink/Context/StoreContextTest.php
@@ -518,8 +518,8 @@ class StoreContextTest extends PHPUnit_Framework_TestCase
     /**
      * @dataProvider phoneNumberFormatDataProvider
      *
-     * @param $input
-     * @param $output
+     * @param string $input  the store context input to retrieve value from.
+     * @param string $output the expected output from the store.
      */
     public function testPhoneNumberFormatting($input, $output)
     {


### PR DESCRIPTION
### Story:

We don't have a way to format phone inputs on flexible mink store when the value displayed on front-end is different from the one capture on the DB when requesting.

### Solution:
Add a way to format phone numbers on US format and ###-###-#### as used on some places.
add tests.

