### PR TITLE
Add spinner to click link to retry when element becomes stale

### DIFF
--- a/bin/init_project
+++ b/bin/init_project
@@ -10,7 +10,7 @@ echo "Installing Composer..."
 echo "Installing Composer dependencies with out dev..."
 composer install --no-interaction --no-suggest
 
-if  [[ ! "$CI" == 'true' ]]; then
+if [[ "${CI:-}" == "true" ]]; then
     echo "Initializing git hooks..."
     "$ROOT"/bin/init_git_hooks
 

--- a/src/Medology/Behat/Mink/FlexibleContext.php
+++ b/src/Medology/Behat/Mink/FlexibleContext.php
@@ -431,7 +431,7 @@ class FlexibleContext extends MinkContext
         $locator = $this->storeContext->injectStoredValues($locator);
 
         Spinner::waitFor(
-            function() use($locator) {
+            function () use ($locator) {
                 $this->scrollToLink($locator)->click();
             }
         );

--- a/src/Medology/Behat/Mink/FlexibleContext.php
+++ b/src/Medology/Behat/Mink/FlexibleContext.php
@@ -429,7 +429,12 @@ class FlexibleContext extends MinkContext
     public function clickLink($locator)
     {
         $locator = $this->storeContext->injectStoredValues($locator);
-        $this->wait->scrollToLink($locator)->click();
+
+        Spinner::waitFor(
+            function() use($locator) {
+                $this->scrollToLink($locator)->click();
+            }
+        );
     }
 
     /**


### PR DESCRIPTION
For: Medology/stdcheck.com#11256

BUG FIX:

**Cause:**
The click link step fails if the element becomes stale after it has been found in the DOM

**Solution:**
Add a spinner to re-retrieve the element and click on it.


Bonus: Upon running `init_project` discovered an error in Bash script about CI being an unbound variable and also CI was failing since submodules hadn't been updated in a while