### PR TITLE
Fix Scrutinizer tries to install submodules

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -8,6 +8,10 @@ build:
   environment:
     php:
       version: 5.6.31
+  # Override dependencies to prevent Scrutinizer from installing submodules (which it neither needs nor has access to)
+  dependencies:
+    override:
+        - git config --global url.git@github.com:.insteadOf git://github.com/
 
 filter:
   excluded_paths:


### PR DESCRIPTION
For #359

## Cause:
Scrutinizer does not have access to the private repo `submodules`. It tries to check out submodules when preparing to inspect any PR against this repo, so it fails with an authorization error.

## Notes:
If we give it access to that, then the code that it runs from a PR against this public repo can use that key to also gain access to `submodules`. Although `submodules` doesn't contain much sensitive data, it does at least contain a list of our private repo's in the non-qa-able-labeler script. There could be more, plus more could be added later.

## Fix:
Scrutinizer does not need the submodules to perform its inspection. So I overrode Scrutinizers `dependencies` step to prevent it from trying to check out the submodules.